### PR TITLE
json variation values are string encoded

### DIFF
--- a/assignment-v2/test-case-0.json
+++ b/assignment-v2/test-case-0.json
@@ -1,5 +1,6 @@
 {
   "experiment": "randomization_algo",
+  "valueType": "string",
   "subjects": [
     "6255e1a70560594e38edcb55",
     "6255e1a7030fc2700972be99",

--- a/assignment-v2/test-case-1.json
+++ b/assignment-v2/test-case-1.json
@@ -1,5 +1,6 @@
 {
   "experiment": "new_user_onboarding",
+  "valueType": "string",
   "subjects": [
     "6255e1a7e56d44937e8aa3c9",
     "6255e1a7ac8f59b030f43889",

--- a/assignment-v2/test-case-2.json
+++ b/assignment-v2/test-case-2.json
@@ -1,5 +1,6 @@
 {
   "experiment": "disabled_experiment_with_overrides",
+  "valueType": "string",
   "subjects": [
     "subject-1",
     "subject-2",

--- a/assignment-v2/test-case-3.json
+++ b/assignment-v2/test-case-3.json
@@ -1,5 +1,6 @@
 {
   "experiment": "targeting_rules_experiment",
+  "valueType": "string",
   "subjectsWithAttributes": [
     {
       "subjectKey": "subject-1",

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -319,9 +319,7 @@
             {
               "name": "control",
               "value": "true",
-              "typedValue": {
-                "test": true
-              },
+              "typedValue": "{\"test\":true}",
               "shardRange": {
                 "start": 0,
                 "end": 5000
@@ -330,9 +328,7 @@
             {
               "name": "treatment",
               "value": "false",
-              "typedValue": {
-                "test": false
-              },
+              "typedValue": "{\"test\":false}",
               "shardRange": {
                 "start": 5000,
                 "end": 10000

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -318,8 +318,10 @@
           "variations": [
             {
               "name": "control",
-              "value": "true",
-              "typedValue": "{\"test\":true}",
+              "value": "{\"test\":true}",
+              "typedValue": {
+                "test": true
+              },
               "shardRange": {
                 "start": 0,
                 "end": 5000
@@ -327,8 +329,10 @@
             },
             {
               "name": "treatment",
-              "value": "false",
-              "typedValue": "{\"test\":false}",
+              "value": "{\"test\":false}",
+              "typedValue": {
+                "test": false
+              },
               "shardRange": {
                 "start": 5000,
                 "end": 10000

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -270,8 +270,9 @@
     },
     "experiment_with_boolean_variations": {
       "subjectShards": 10000,
-      "enabled": true,
+      "overrides": {},
       "typedOverrides": {},
+      "enabled": true,
       "rules": [
         {
           "allocationKey": "allocation-experiment-6",
@@ -306,8 +307,9 @@
     },
     "experiment_with_json_variations": {
       "subjectShards": 10000,
-      "enabled": true,
+      "overrides": {},
       "typedOverrides": {},
+      "enabled": true,
       "rules": [
         {
           "allocationKey": "allocation-experiment-7",

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -271,6 +271,7 @@
     "experiment_with_boolean_variations": {
       "subjectShards": 10000,
       "enabled": true,
+      "typedOverrides": {},
       "rules": [
         {
           "allocationKey": "allocation-experiment-6",
@@ -306,6 +307,7 @@
     "experiment_with_json_variations": {
       "subjectShards": 10000,
       "enabled": true,
+      "typedOverrides": {},
       "rules": [
         {
           "allocationKey": "allocation-experiment-7",


### PR DESCRIPTION
## motivation

To support consistency between the RAC API and the test files:

* return stringified json in the `value` field of the variation
* continue returning json in the `typedValue` field of the variation

**Fixups**

* added `valueType` field to all test cases to avoid test code needing to support default value - we control these files and its ok to go back and add this
* added `overrides` and `typedOverrides` fields where they are missing since that meets the RAC API spec