### PR TITLE
Add obfuscated rac file

### DIFF
--- a/rac-experiments-v3-obfuscated.json
+++ b/rac-experiments-v3-obfuscated.json
@@ -1,0 +1,350 @@
+{
+  "flags": {
+    "21da1d71c0e08e4fbbcc61d79700f073": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "allocation-experiment-1",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "allocation-experiment-1": {
+          "percentExposure": 0.4533,
+          "variations": [
+            {
+              "name": "control",
+              "value": "control",
+              "typedValue": "control",
+              "shardRange": {
+                "start": 0,
+                "end": 3333
+              }
+            },
+            {
+              "name": "red",
+              "value": "red",
+              "typedValue": "red",
+              "shardRange": {
+                "start": 3333,
+                "end": 6666
+              }
+            },
+            {
+              "name": "green",
+              "value": "green",
+              "typedValue": "green",
+              "shardRange": {
+                "start": 6666,
+                "end": 10000
+              }
+            }
+          ]
+        }
+      }
+    },
+    "5c18eee9f9f9ecefefbee4924a84b31a": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "allocation-experiment-2",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "allocation-experiment-2": {
+          "percentExposure": 0.95,
+          "variations": [
+            {
+              "name": "control",
+              "value": "control",
+              "typedValue": "control",
+              "shardRange": {
+                "start": 0,
+                "end": 2500
+              }
+            },
+            {
+              "name": "red",
+              "value": "red",
+              "typedValue": "red",
+              "shardRange": {
+                "start": 2500,
+                "end": 5000
+              }
+            },
+            {
+              "name": "green",
+              "value": "green",
+              "typedValue": "green",
+              "shardRange": {
+                "start": 5000,
+                "end": 7500
+              }
+            },
+            {
+              "name": "purple",
+              "value": "purple",
+              "typedValue": "purple",
+              "shardRange": {
+                "start": 7500,
+                "end": 10000
+              }
+            }
+          ]
+        }
+      }
+    },
+    "71a5f49930b6cdc7ec2cae4e6d2ce0aa": {
+      "subjectShards": 10000,
+      "overrides": {
+        "0bcbfc2660c78c549b0fbf870e3dc3ea": "treatment",
+        "a90ea45116d251a43da56e03d3dd7275": "control",
+        "e5cb922bc7e1a13636e361a424b4a3f3": "control",
+        "50a681dcd4046400e5c675e85b69b4ac": "control"
+      },
+      "typedOverrides": {
+        "0bcbfc2660c78c549b0fbf870e3dc3ea": "treatment",
+        "a90ea45116d251a43da56e03d3dd7275": "control",
+        "e5cb922bc7e1a13636e361a424b4a3f3": "control",
+        "50a681dcd4046400e5c675e85b69b4ac": "control"
+      },
+      "enabled": false,
+      "rules": [
+        {
+          "allocationKey": "allocation-experiment-3",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "allocation-experiment-3": {
+          "percentExposure": 1,
+          "variations": [
+            {
+              "name": "control",
+              "value": "control",
+              "typedValue": "control",
+              "shardRange": {
+                "start": 0,
+                "end": 5000
+              }
+            },
+            {
+              "name": "treatment",
+              "value": "treatment",
+              "typedValue": "treatment",
+              "shardRange": {
+                "start": 5000,
+                "end": 10000
+              }
+            }
+          ]
+        }
+      }
+    },
+    "7030079cf2004c4018e931a247f37f19": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "allocation-experiment-4",
+          "conditions": [
+            {
+              "value": [
+                "9e304d4e8df1b74cfa009913198428ab",
+                "c31b32364ce19ca8fcd150a417ecce58"
+              ],
+              "operator": "27457ce369f2a74203396a35ef537c0b",
+              "attribute": "913f9c49dcb544e2087cee284f4a00b7"
+            },
+            {
+              "value": "MQ==",
+              "operator": "cd6a9bd2a175104eed40f0d33a8b4020",
+              "attribute": "2af72f100c356273d46284f6fd1dfc08"
+            }
+          ]
+        },
+        {
+          "allocationKey": "allocation-experiment-4",
+          "conditions": [
+            {
+              "value": [
+                "8a7d7ba288ca0f0ea1ecf975b026e8e1"
+              ],
+              "operator": "602f5ee0b6e84fe29f43ab48b9e1addf",
+              "attribute": "e909c2d7067ea37437cf97fe11d91bd0"
+            }
+          ]
+        },
+        {
+          "allocationKey": "allocation-experiment-4",
+          "conditions": [
+            {
+              "value": "LipnZXRlcHBvLmNvbQ==",
+              "operator": "05015086bdd8402218f6aad6528bef08",
+              "attribute": "0c83f57c786a0b4a39efab23731c7ebc"
+            }
+          ]
+        }
+      ],
+      "allocations": {
+        "allocation-experiment-4": {
+          "percentExposure": 1,
+          "variations": [
+            {
+              "name": "control",
+              "value": "control",
+              "typedValue": "control",
+              "shardRange": {
+                "start": 0,
+                "end": 5000
+              }
+            },
+            {
+              "name": "treatment",
+              "value": "treatment",
+              "typedValue": "treatment",
+              "shardRange": {
+                "start": 5000,
+                "end": 10000
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fde048629f498c67593dd9517ad2c600": {
+      "subjectShards": 10000,
+      "overrides": {
+        "0bcbfc2660c78c549b0fbf870e3dc3ea": "5",
+        "a90ea45116d251a43da56e03d3dd7275": "10",
+        "e5cb922bc7e1a13636e361a424b4a3f3": "10",
+        "50a681dcd4046400e5c675e85b69b4ac": "10"
+      },
+      "typedOverrides": {
+        "0bcbfc2660c78c549b0fbf870e3dc3ea": 5,
+        "a90ea45116d251a43da56e03d3dd7275": 10,
+        "e5cb922bc7e1a13636e361a424b4a3f3": 10,
+        "50a681dcd4046400e5c675e85b69b4ac": 10
+      },
+      "enabled": false,
+      "rules": [
+        {
+          "allocationKey": "allocation-experiment-5",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "allocation-experiment-5": {
+          "percentExposure": 1,
+          "variations": [
+            {
+              "name": "control",
+              "value": "50",
+              "typedValue": 50,
+              "shardRange": {
+                "start": 0,
+                "end": 5000
+              }
+            },
+            {
+              "name": "treatment",
+              "value": "100",
+              "typedValue": 100,
+              "shardRange": {
+                "start": 5000,
+                "end": 10000
+              }
+            }
+          ]
+        }
+      }
+    },
+    "8fc1fb33379d78c8a9edbf43afd6703a": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "allocation-experiment-6",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "allocation-experiment-6": {
+          "percentExposure": 1,
+          "variations": [
+            {
+              "name": "control",
+              "value": "true",
+              "typedValue": true,
+              "shardRange": {
+                "start": 0,
+                "end": 5000
+              }
+            },
+            {
+              "name": "treatment",
+              "value": "false",
+              "typedValue": false,
+              "shardRange": {
+                "start": 5000,
+                "end": 10000
+              }
+            }
+          ]
+        }
+      }
+    },
+    "0e28708a2acb0c28de9477a1b13a9352": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "allocation-experiment-7",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "allocation-experiment-7": {
+          "percentExposure": 1,
+          "variations": [
+            {
+              "name": "control",
+              "value": "{\"test\":true}",
+              "typedValue": {
+                "test": true
+              },
+              "shardRange": {
+                "start": 0,
+                "end": 5000
+              }
+            },
+            {
+              "name": "treatment",
+              "value": "{\"test\":false}",
+              "typedValue": {
+                "test": false
+              },
+              "shardRange": {
+                "start": 5000,
+                "end": 10000
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Generated by this script: https://github.com/Eppo-exp/js-client-sdk-common/pull/24/files#diff-b77e6b71bcefeeaea5d0e6da2216201d4cd513f0da4132421f03084ee3a22b82

I think it's helpful to have a script somewhere to generate this programmatically, although I don't know if leaving it in the common sdk code makes the most sense.

Hashes the flag keys
And also obfuscates the `value`, `operator`, and `attribute` in each of the conditions in the rules, e.g.
```
      "rules": [
        {
          "allocationKey": "allocation-experiment-4",
          "conditions": [
            {
              "value": [
                "9e304d4e8df1b74cfa009913198428ab",
                "c31b32364ce19ca8fcd150a417ecce58"
              ],
              "operator": "27457ce369f2a74203396a35ef537c0b",
              "attribute": "913f9c49dcb544e2087cee284f4a00b7"
            },
            {
              "value": "MQ==",
              "operator": "cd6a9bd2a175104eed40f0d33a8b4020",
              "attribute": "2af72f100c356273d46284f6fd1dfc08"
            }
          ]
        },
```