### PR TITLE
Add algorithmType to test RAC

### DIFF
--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -22,7 +22,8 @@
               "shardRange": {
                 "start": 0,
                 "end": 3333
-              }
+              },
+              "algorithmType": "CONSTANT"
             },
             {
               "name": "red",
@@ -31,7 +32,8 @@
               "shardRange": {
                 "start": 3333,
                 "end": 6666
-              }
+              },
+              "algorithmType": "CONSTANT"
             },
             {
               "name": "green",
@@ -40,7 +42,8 @@
               "shardRange": {
                 "start": 6666,
                 "end": 10000
-              }
+              },
+              "algorithmType": "CONSTANT"
             }
           ]
         }

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -345,6 +345,46 @@
           ]
         }
       }
+    },
+    "test_bandit_1": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "bandit",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "bandit": {
+          "percentExposure": 0.4533,
+				  "logActions": true,
+          "variations": [
+            {
+              "name": "control",
+              "value": "control",
+              "typedValue": "control",
+              "shardRange": {
+                "start": 0,
+                "end": 2000
+              },
+              "algorithmType": "CONSTANT"
+            },
+            {
+              "name": "bandit",
+              "value": "banner-bandit",
+              "typedValue": "banner-bandit",
+              "shardRange": {
+                "start": 2000,
+                "end": 10000
+              },
+              "algorithmType": "CONTEXTUAL_BANDIT"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -363,7 +363,6 @@
       "allocations": {
         "bandit": {
           "percentExposure": 0.4533,
-				  "logActions": true,
           "variations": [
             {
               "name": "control",


### PR DESCRIPTION
This change adds the `algorithmType` field to our test RAC in two places:
1. An existing allocation, where its value is always `CONSTANT`
2. A new flag and allocation with a `CONTEXTUAL_BANDIT`

The reason to do this is to make sure the presence (or later, lack of presence) of these fields doesn't break existing SDKs.

This will be made easier by the tests automatically running on push to main once pull request #3 is merged.