### PR TITLE
Sameeran/no shipped variation in experiment

### DIFF
--- a/rac-experiments-v3-hashed-keys.json
+++ b/rac-experiments-v3-hashed-keys.json
@@ -378,7 +378,7 @@
         "allocation-experiment-1": {
           "percentExposure": 0.4533,
           "statusQuoVariationKey": "variation-7",
-          "shippedVariationKey": "variation-8",
+          "shippedVariationKey": null,
           "holdouts": [
             {
               "holdoutKey": "holdout-2",

--- a/rac-experiments-v3-obfuscated.json
+++ b/rac-experiments-v3-obfuscated.json
@@ -427,7 +427,7 @@
         "allocation-experiment-1": {
           "percentExposure": 0.4533,
           "statusQuoVariationKey": "variation-7",
-          "shippedVariationKey": "variation-8",
+          "shippedVariationKey": null,
           "holdouts": [
             {
               "holdoutKey": "holdout-2",

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -427,7 +427,7 @@
         "allocation-experiment-1": {
           "percentExposure": 0.4533,
           "statusQuoVariationKey": "variation-7",
-          "shippedVariationKey": "variation-8",
+          "shippedVariationKey": null,
           "holdouts": [
             {
               "holdoutKey": "holdout-2",


### PR DESCRIPTION
I missed this. It doesn't affect any of the tests because they don't use the shipped variation field for experiment allocations.

But for the sake of accurately representing the intended behavior: experiment allocations being held out should have no shipped variation. These will be set to `null`.