### PR TITLE
Have at least one testa data allocation with no holdouts

### DIFF
--- a/rac-experiments-v3-hashed-keys.json
+++ b/rac-experiments-v3-hashed-keys.json
@@ -16,7 +16,6 @@
           "percentExposure": 0.4533,
           "statusQuoVariationKey": null,
           "shippedVariationKey": null,
-          "holdouts": [],
           "variations": [
             {
               "name": "control",

--- a/rac-experiments-v3-obfuscated.json
+++ b/rac-experiments-v3-obfuscated.json
@@ -16,7 +16,6 @@
           "percentExposure": 0.4533,
           "statusQuoVariationKey": null,
           "shippedVariationKey": null,
-          "holdouts": [],
           "variations": [
             {
               "name": "control",

--- a/rac-experiments-v3.json
+++ b/rac-experiments-v3.json
@@ -16,7 +16,6 @@
           "percentExposure": 0.4533,
           "statusQuoVariationKey": null,
           "shippedVariationKey": null,
-          "holdouts": [],
           "variations": [
             {
               "name": "control",


### PR DESCRIPTION
To make sure our SDKs are defensive with newly added functionality, let's have one of these allocations not have a holdout array at all.