### PR TITLE
Add additional tests for the UFC

### DIFF
--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -64,6 +64,62 @@
       ],
       "totalShards": 10000
     },
+    "3d88068611498391d5c8307467e6fa2c": {
+      "key": "3d88068611498391d5c8307467e6fa2c",
+      "enabled": true,
+      "variationType": "INTEGER",
+      "variations": {
+        "one": {
+          "key": "one",
+          "value": 1
+        },
+        "pi": {
+          "key": "pi",
+          "value": 3.1415926
+        }
+      },
+      "allocations": [
+        {
+          "key": "valid",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "e909c2d7067ea37437cf97fe11d91bd0",
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "value": [
+                    "c2aadac2ca30ca8aadfbe331ae180d28"
+                  ]
+                }
+              ]
+            }
+          ],
+          "startAt": null,
+          "endAt": null,
+          "splits": [
+            {
+              "variationKey": "one",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "invalid",
+          "rules": [],
+          "startAt": null,
+          "endAt": null,
+          "splits": [
+            {
+              "variationKey": "pi",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
     "ea55330f6cbbaf8f57556df645c037e2": {
       "key": "ea55330f6cbbaf8f57556df645c037e2",
       "enabled": true,
@@ -161,6 +217,303 @@
             }
           ],
           "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
+    "dd2880e486d8a74a7daf902f93a19952": {
+      "key": "dd2880e486d8a74a7daf902f93a19952",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": {
+          "key": "old",
+          "value": "old"
+        },
+        "current": {
+          "key": "current",
+          "value": "current"
+        },
+        "new": {
+          "key": "new",
+          "value": "new"
+        }
+      },
+      "allocations": [
+        {
+          "key": "old-versions",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "2af72f100c356273d46284f6fd1dfc08",
+                  "operator": "c562607189d77eb9dfb707464c1e7b0b",
+                  "value": "MS41LjA="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "current-versions",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "2af72f100c356273d46284f6fd1dfc08",
+                  "operator": "32d35312e8f24bc1669bd2b45c00d47c",
+                  "value": "MS41LjA="
+                },
+                {
+                  "attribute": "2af72f100c356273d46284f6fd1dfc08",
+                  "operator": "cc981ecc65ecf63ad1673cbec9c64198",
+                  "value": "Mi4yLjEz"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "current",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "new-versions",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "2af72f100c356273d46284f6fd1dfc08",
+                  "operator": "cd6a9bd2a175104eed40f0d33a8b4020",
+                  "value": "My4xLjA="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "new",
+              "shards": []
+            }
+          ]
+        }
+      ],
+      "totalShards": 10000
+    },
+    "0e4820f073429772c0fa3e831c8d13c7": {
+      "key": "0e4820f073429772c0fa3e831c8d13c7",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "small": {
+          "key": "small",
+          "value": "small"
+        },
+        "medium": {
+          "key": "medium",
+          "value": "medium"
+        },
+        "large": {
+          "key": "large",
+          "value": "large"
+        }
+      },
+      "allocations": [
+        {
+          "key": "small-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "f7bd60b75b29d79b660a2859395c1a24",
+                  "operator": "c562607189d77eb9dfb707464c1e7b0b",
+                  "value": "MTA="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "small",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "medum-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "f7bd60b75b29d79b660a2859395c1a24",
+                  "operator": "32d35312e8f24bc1669bd2b45c00d47c",
+                  "value": "MTA="
+                },
+                {
+                  "attribute": "f7bd60b75b29d79b660a2859395c1a24",
+                  "operator": "cc981ecc65ecf63ad1673cbec9c64198",
+                  "value": "MjA="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "medium",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "large-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "f7bd60b75b29d79b660a2859395c1a24",
+                  "operator": "cd6a9bd2a175104eed40f0d33a8b4020",
+                  "value": "MjU="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "large",
+              "shards": []
+            }
+          ]
+        }
+      ],
+      "totalShards": 10000
+    },
+    "3f8ba2f25085acef84472ead80f39739": {
+      "key": "3f8ba2f25085acef84472ead80f39739",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": {
+          "key": "old",
+          "value": "old"
+        },
+        "current": {
+          "key": "current",
+          "value": "current"
+        },
+        "new": {
+          "key": "new",
+          "value": "new"
+        }
+      },
+      "allocations": [
+        {
+          "key": "old-versions",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ],
+          "endAt": "2002-10-31T09:00:00.594Z"
+        },
+        {
+          "key": "future-versions",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "future",
+              "shards": []
+            }
+          ],
+          "startAt": "2052-10-31T09:00:00.594Z"
+        },
+        {
+          "key": "current-versions",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "current",
+              "shards": []
+            }
+          ],
+          "startAt": "2022-10-31T09:00:00.594Z",
+          "endAt": "2050-10-31T09:00:00.594Z"
+        }
+      ],
+      "totalShards": 10000
+    },
+    "44bf29f34bdd73ff93a6e2579c973596": {
+      "key": "44bf29f34bdd73ff93a6e2579c973596",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": {
+          "key": "old",
+          "value": "old"
+        },
+        "new": {
+          "key": "new",
+          "value": "new"
+        }
+      },
+      "allocations": [
+        {
+          "key": "null-operator",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "f7bd60b75b29d79b660a2859395c1a24",
+                  "operator": "dbd9c38e0339e6c34bd48cafc59be388",
+                  "value": "dHJ1ZQ=="
+                }
+              ]
+            },
+            {
+              "conditions": [
+                {
+                  "attribute": "f7bd60b75b29d79b660a2859395c1a24",
+                  "operator": "c562607189d77eb9dfb707464c1e7b0b",
+                  "value": "MTA="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "not-null-operator",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "f7bd60b75b29d79b660a2859395c1a24",
+                  "operator": "dbd9c38e0339e6c34bd48cafc59be388",
+                  "value": "ZmFsc2U="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "new",
+              "shards": []
+            }
+          ]
         }
       ],
       "totalShards": 10000

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -416,37 +416,34 @@
       "allocations": [
         {
           "key": "old-versions",
-          "rules": [],
           "splits": [
             {
               "variationKey": "old",
               "shards": []
             }
           ],
-          "endAt": "2002-10-31T09:00:00.594Z"
+          "endAt": "2002-10-31T09:00:00.594"
         },
         {
           "key": "future-versions",
-          "rules": [],
           "splits": [
             {
               "variationKey": "future",
               "shards": []
             }
           ],
-          "startAt": "2052-10-31T09:00:00.594Z"
+          "startAt": "2052-10-31T09:00:00.594"
         },
         {
           "key": "current-versions",
-          "rules": [],
           "splits": [
             {
               "variationKey": "current",
               "shards": []
             }
           ],
-          "startAt": "2022-10-31T09:00:00.594Z",
-          "endAt": "2050-10-31T09:00:00.594Z"
+          "startAt": "2022-10-31T09:00:00.594",
+          "endAt": "2050-10-31T09:00:00.594"
         }
       ],
       "totalShards": 10000

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -64,6 +64,60 @@
       ],
       "totalShards": 10000
     },
+    "invalid-value-flag": {
+      "key": "invalid-value-flag",
+      "enabled": true,
+      "variationType": "INTEGER",
+      "variations": {
+        "one": {
+          "key": "one",
+          "value": 1
+        },
+        "pi": {
+          "key": "pi",
+          "value": 3.1415926
+        }
+      },
+      "allocations": [
+        {
+          "key": "valid",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "country",
+                  "operator": "ONE_OF",
+                  "value": ["Canada"]
+                }
+              ]
+            }
+          ],
+          "startAt": null,
+          "endAt": null,
+          "splits": [
+            {
+              "variationKey": "one",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "invalid",
+          "rules": [],
+          "startAt": null,
+          "endAt": null,
+          "splits": [
+            {
+              "variationKey": "pi",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
     "kill-switch": {
       "key": "kill-switch",
       "enabled": true,
@@ -147,6 +201,270 @@
             }
           ],
           "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
+    "semver-test": {
+      "key": "semver-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": { "key": "old", "value": "old"},
+        "current": { "key": "current", "value": "current"},
+        "new": { "key": "new", "value": "new"}
+      },
+      "allocations": [
+        {
+          "key": "old-versions",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "version",
+                  "operator": "LT",
+                  "value": "1.5.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "current-versions",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "version",
+                  "operator": "GTE",
+                  "value": "1.5.0"
+                },
+                {
+                  "attribute": "version",
+                  "operator": "LTE",
+                  "value": "2.2.13"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "current",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "new-versions",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "version",
+                  "operator": "GT",
+                  "value": "3.1.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "new",
+              "shards": []
+            }
+          ]
+        }
+      ],
+      "totalShards": 10000
+    },
+    "comparator-operator-test": {
+      "key": "comparator-operator-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "small": { "key": "small", "value": "small"},
+        "medium": { "key": "medium", "value": "medium"},
+        "large": { "key": "large", "value": "large"}
+      },
+      "allocations": [
+        {
+          "key": "small-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "LT",
+                  "value": 10
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "small",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "medum-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "GTE",
+                  "value": 10
+                },
+                {
+                  "attribute": "size",
+                  "operator": "LTE",
+                  "value": 20
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "medium",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "large-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "GT",
+                  "value": 25
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "large",
+              "shards": []
+            }
+          ]
+        }
+      ],
+      "totalShards": 10000
+    },
+    "start-and-end-date-test": {
+      "key": "start-and-end-date-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": { "key": "old", "value": "old"},
+        "current": { "key": "current", "value": "current"},
+        "new": { "key": "new", "value": "new"}
+      },
+      "allocations": [
+        {
+          "key": "old-versions",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ],
+          "endAt": "2002-10-31T09:00:00.594Z"
+        },
+        {
+          "key": "future-versions",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "future",
+              "shards": []
+            }
+          ],
+          "startAt": "2052-10-31T09:00:00.594Z"
+        },
+        {
+          "key": "current-versions",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "current",
+              "shards": []
+            }
+          ],
+          "startAt": "2022-10-31T09:00:00.594Z",
+          "endAt": "2050-10-31T09:00:00.594Z"
+        }
+      ],
+      "totalShards": 10000
+    },
+    "null-operator-test": {
+      "key": "null-operator-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": { "key": "old", "value": "old"},
+        "new": { "key": "new", "value": "new"}
+      },
+      "allocations": [
+        {
+          "key": "null-operator",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "IS_NULL",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "LTE",
+                  "value": 10
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "not-null-operator",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "IS_NULL",
+                  "value": false
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "new",
+              "shards": []
+            }
+          ]
         }
       ],
       "totalShards": 10000

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -433,7 +433,7 @@
               "conditions": [
                 {
                   "attribute": "size",
-                  "operator": "LTE",
+                  "operator": "LT",
                   "value": 10
                 }
               ]

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -373,37 +373,34 @@
       "allocations": [
         {
           "key": "old-versions",
-          "rules": [],
           "splits": [
             {
               "variationKey": "old",
               "shards": []
             }
           ],
-          "endAt": "2002-10-31T09:00:00.594Z"
+          "endAt": "2002-10-31T09:00:00.594"
         },
         {
           "key": "future-versions",
-          "rules": [],
           "splits": [
             {
               "variationKey": "future",
               "shards": []
             }
           ],
-          "startAt": "2052-10-31T09:00:00.594Z"
+          "startAt": "2052-10-31T09:00:00.594"
         },
         {
           "key": "current-versions",
-          "rules": [],
           "splits": [
             {
               "variationKey": "current",
               "shards": []
             }
           ],
-          "startAt": "2022-10-31T09:00:00.594Z",
-          "endAt": "2050-10-31T09:00:00.594Z"
+          "startAt": "2022-10-31T09:00:00.594",
+          "endAt": "2050-10-31T09:00:00.594"
         }
       ],
       "totalShards": 10000

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -1,0 +1,32 @@
+{
+    "flag": "comparator-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "subjects": [
+      {
+        "subjectKey": "alice",
+        "subjectAttributes": {"size": 5, "country": "US"},
+        "assignment": "small"
+      },
+      {
+        "subjectKey": "bob",
+        "subjectAttributes": {"size": 10, "country": "Canada"},
+        "assignment": "medium"
+      },
+      {
+        "subjectKey": "charlie",
+        "subjectAttributes": {"size": 25},
+        "assignment": "unknown"
+      },
+      {
+        "subjectKey": "david",
+        "subjectAttributes": {"size": 26},
+        "assignment": "large"
+      },
+      {
+        "subjectKey": "elize",
+        "subjectAttributes": {"country": "UK"},
+        "assignment": "unknown"
+      }
+    ]
+  }

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -1,0 +1,23 @@
+{
+    "flag": "invalid-value-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 42,
+    "subjects": [
+      {
+        "subjectKey": "alice",
+        "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
+        "assignment": 42
+      },
+      {
+        "subjectKey": "bob",
+        "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
+        "assignment": 1
+      },
+      {
+        "subjectKey": "charlie",
+        "subjectAttributes": {"age": 50},
+        "assignment": 42
+      }
+    ]
+  }
+  

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -1,0 +1,32 @@
+{
+    "flag": "null-operator-flag",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "subjects": [
+      {
+        "subjectKey": "alice",
+        "subjectAttributes": {"size": 5, "country": "US"},
+        "assignment": "old"
+      },
+      {
+        "subjectKey": "bob",
+        "subjectAttributes": {"size": 10, "country": "Canada"},
+        "assignment": "new"
+      },
+      {
+        "subjectKey": "charlie",
+        "subjectAttributes": {"size": null},
+        "assignment": "old"
+      },
+      {
+        "subjectKey": "david",
+        "subjectAttributes": {"size": 26},
+        "assignment": "new"
+      },
+      {
+        "subjectKey": "elize",
+        "subjectAttributes": {"country": "UK"},
+        "assignment": "old"
+      }
+    ]
+  }

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -1,7 +1,7 @@
 {
-    "flag": "null-operator-flag",
+    "flag": "null-operator-test",
     "variationType": "STRING",
-    "defaultValue": "unknown",
+    "defaultValue": "default-null",
     "subjects": [
       {
         "subjectKey": "alice",

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -1,0 +1,37 @@
+{
+    "flag": "semver-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "subjects": [
+      {
+        "subjectKey": "alice",
+        "subjectAttributes": {"version": "1.15.0", "country": "US"},
+        "assignment": "current"
+      },
+      {
+        "subjectKey": "bob",
+        "subjectAttributes": {"version": "0.20.1", "country": "Canada"},
+        "assignment": "old"
+      },
+      {
+        "subjectKey": "charlie",
+        "subjectAttributes": {"version": "2.1.13"},
+        "assignment": "current"
+      },
+      {
+        "subjectKey": "david",
+        "subjectAttributes": {"version": "3.1.0"},
+        "assignment": "unknown"
+      },
+      {
+        "subjectKey": "elize",
+        "subjectAttributes": {"version": "3.1.1"},
+        "assignment": "new"
+      },
+      {
+        "subjectKey": "frank",
+        "subjectAttributes": {"version": "1.5.0"},
+        "assignment": "current"
+      }
+    ]
+  }

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -1,0 +1,22 @@
+{
+    "flag": "start-and-end-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "subjects": [
+      {
+        "subjectKey": "alice",
+        "subjectAttributes": {"version": "1.15.0", "country": "US"},
+        "assignment": "current"
+      },
+      {
+        "subjectKey": "bob",
+        "subjectAttributes": {"version": "0.20.1", "country": "Canada"},
+        "assignment": "current"
+      },
+      {
+        "subjectKey": "charlie",
+        "subjectAttributes": {"version": "2.1.13"},
+        "assignment": "current"
+      }
+    ]
+}


### PR DESCRIPTION
Adding extra tests to the test suite to make sure all SDKs handle these correctly:

- An invalid type: added an integer flag with a non-integer variation. This should return the default value (based on discussion with Aaron)
- A semver test: making sure semantic versions are handled correctly
- A comparator test: making sure numerical comparisons are handled correctly
- Start and end date test: making sure all SKDs adhere to start and end dates on allocations (this test will break in 2052)
- Null operator test: making sure we handle null and non-null conditions correctly