### PR TITLE
[ufc] add null attribute test

### DIFF
--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -286,6 +286,10 @@
         "NA==": {
           "key": "NA==",
           "value": "NA=="
+        },
+        "NQ==": {
+          "key": "NQ==",
+          "value": "NQ=="
         }
       },
       "allocations": [
@@ -373,6 +377,29 @@
           "splits": [
             {
               "variationKey": "NA==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "NS1mb3ItbWF0Y2hlcy1udWxs",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "ff0d5b33a2ccfe9bd8cea5bee51f0497",
+                  "value": [
+                    "37a6259cc0c1dae299a7866489dff0bd"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "NQ==",
               "shards": []
             }
           ]

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -285,6 +285,10 @@
         "4": {
           "key": "4",
           "value": 4
+        },
+        "5": {
+          "key": "5",
+          "value": 5
         }
       },
       "allocations": [
@@ -371,6 +375,29 @@
           "splits": [
             {
               "variationKey": "4",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "5-for-matches-null",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "null_flag",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "null"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "5",
               "shards": []
             }
           ],

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -77,6 +77,11 @@
         "subjectKey": "owen",
         "subjectAttributes": {"null_flag": null},
         "assignment": 0
+      },
+      {
+        "subjectKey": "pete",
+        "subjectAttributes": {},
+        "assignment": 0
       }
     ]
   }

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -67,6 +67,16 @@
         "subjectKey": "mike",
         "subjectAttributes": {"not_one_of_flag": "false"},
         "assignment": 0
+      },
+      {
+        "subjectKey": "nicole",
+        "subjectAttributes": {"null_flag": "null"},
+        "assignment": 5
+      },
+      {
+        "subjectKey": "owen",
+        "subjectAttributes": {"null_flag": null},
+        "assignment": 0
       }
     ]
   }


### PR DESCRIPTION
Adds a test case for when subject attribute value is null. In that case, no allocation should match.