### PR TITLE
FF-2498 Assignment Details test data

### DIFF
--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -1,88 +1,117 @@
 {
-    "flag": "boolean-one-of-matches",
-    "variationType": "INTEGER",
-    "defaultValue": 0,
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"one_of_flag": true},
-        "assignment": 1
+  "flag": "boolean-one-of-matches",
+  "variationType": "INTEGER",
+  "defaultValue": 0,
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "one_of_flag": true
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"one_of_flag": false },
-        "assignment": 0
+      "assignment": 1
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "one_of_flag": false
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"one_of_flag": "True"},
-        "assignment": 0
+      "assignment": 0
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "one_of_flag": "True"
       },
-      {
-        "subjectKey": "derek",
-        "subjectAttributes": {"matches_flag": true},
-        "assignment": 2
+      "assignment": 0
+    },
+    {
+      "subjectKey": "derek",
+      "subjectAttributes": {
+        "matches_flag": true
       },
-      {
-        "subjectKey": "erica",
-        "subjectAttributes": {"matches_flag": false},
-        "assignment": 0
+      "assignment": 2
+    },
+    {
+      "subjectKey": "erica",
+      "subjectAttributes": {
+        "matches_flag": false
       },
-      {
-        "subjectKey": "frank",
-        "subjectAttributes": {"not_matches_flag": false},
-        "assignment": 0
+      "assignment": 0
+    },
+    {
+      "subjectKey": "frank",
+      "subjectAttributes": {
+        "not_matches_flag": false
       },
-      {
-        "subjectKey": "george",
-        "subjectAttributes": {"not_matches_flag": true},
-        "assignment": 4
+      "assignment": 0
+    },
+    {
+      "subjectKey": "george",
+      "subjectAttributes": {
+        "not_matches_flag": true
       },
-      {
-        "subjectKey": "haley",
-        "subjectAttributes": {"not_matches_flag": "False"},
-        "assignment": 4
+      "assignment": 4
+    },
+    {
+      "subjectKey": "haley",
+      "subjectAttributes": {
+        "not_matches_flag": "False"
       },
-      {
-        "subjectKey": "ivy",
-        "subjectAttributes": {"not_one_of_flag": true},
-        "assignment": 3
+      "assignment": 4
+    },
+    {
+      "subjectKey": "ivy",
+      "subjectAttributes": {
+        "not_one_of_flag": true
       },
-      {
-        "subjectKey": "julia",
-        "subjectAttributes": {"not_one_of_flag": false},
-        "assignment": 0
+      "assignment": 3
+    },
+    {
+      "subjectKey": "julia",
+      "subjectAttributes": {
+        "not_one_of_flag": false
       },
-      {
-        "subjectKey": "kim",
-        "subjectAttributes": {"not_one_of_flag": "False"},
-        "assignment": 3
+      "assignment": 0
+    },
+    {
+      "subjectKey": "kim",
+      "subjectAttributes": {
+        "not_one_of_flag": "False"
       },
-      {
-        "subjectKey": "lucas",
-        "subjectAttributes": {"not_one_of_flag": "true"},
-        "assignment": 3
+      "assignment": 3
+    },
+    {
+      "subjectKey": "lucas",
+      "subjectAttributes": {
+        "not_one_of_flag": "true"
       },
-      {
-        "subjectKey": "mike",
-        "subjectAttributes": {"not_one_of_flag": "false"},
-        "assignment": 0
+      "assignment": 3
+    },
+    {
+      "subjectKey": "mike",
+      "subjectAttributes": {
+        "not_one_of_flag": "false"
       },
-      {
-        "subjectKey": "nicole",
-        "subjectAttributes": {"null_flag": "null"},
-        "assignment": 5
+      "assignment": 0
+    },
+    {
+      "subjectKey": "nicole",
+      "subjectAttributes": {
+        "null_flag": "null"
       },
-      {
-        "subjectKey": "owen",
-        "subjectAttributes": {"null_flag": null},
-        "assignment": 0
+      "assignment": 5
+    },
+    {
+      "subjectKey": "owen",
+      "subjectAttributes": {
+        "null_flag": null
       },
-      {
-        "subjectKey": "pete",
-        "subjectAttributes": {},
-        "assignment": 0
-      }
-    ]
-  }
-
+      "assignment": 0
+    },
+    {
+      "subjectKey": "pete",
+      "subjectAttributes": {},
+      "assignment": 0
+    }
+  ]
+}

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -8,110 +8,774 @@
       "subjectAttributes": {
         "one_of_flag": true
       },
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-one-of\".",
+        "variationKey": "1",
+        "variationValue": 1,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "one_of_flag",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "1-for-one-of",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
       "subjectAttributes": {
         "one_of_flag": false
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "one_of_flag": "True"
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "derek",
       "subjectAttributes": {
         "matches_flag": true
       },
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-matches\".",
+        "variationKey": "2",
+        "variationValue": 2,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "matches_flag",
+              "operator": "MATCHES",
+              "value": "true"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "2-for-matches",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          }
+        ]
+      }
     },
     {
       "subjectKey": "erica",
       "subjectAttributes": {
         "matches_flag": false
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "frank",
       "subjectAttributes": {
         "not_matches_flag": false
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "george",
       "subjectAttributes": {
         "not_matches_flag": true
       },
-      "assignment": 4
+      "assignment": 4,
+      "assignmentDetails": {
+        "value": 4,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
+        "variationKey": "4",
+        "variationValue": 4,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "not_matches_flag",
+              "operator": "NOT_MATCHES",
+              "value": "false"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "4-for-not-matches",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          }
+        ]
+      }
     },
     {
       "subjectKey": "haley",
       "subjectAttributes": {
         "not_matches_flag": "False"
       },
-      "assignment": 4
+      "assignment": 4,
+      "assignmentDetails": {
+        "value": 4,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
+        "variationKey": "4",
+        "variationValue": 4,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "not_matches_flag",
+              "operator": "NOT_MATCHES",
+              "value": "false"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "4-for-not-matches",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          }
+        ]
+      }
     },
     {
       "subjectKey": "ivy",
       "subjectAttributes": {
         "not_one_of_flag": true
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
+        "variationKey": "3",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "not_one_of_flag",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "false"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "3-for-not-one-of",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          }
+        ]
+      }
     },
     {
       "subjectKey": "julia",
       "subjectAttributes": {
         "not_one_of_flag": false
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "kim",
       "subjectAttributes": {
         "not_one_of_flag": "False"
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
+        "variationKey": "3",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "not_one_of_flag",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "false"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "3-for-not-one-of",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          }
+        ]
+      }
     },
     {
       "subjectKey": "lucas",
       "subjectAttributes": {
         "not_one_of_flag": "true"
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
+        "variationKey": "3",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "not_one_of_flag",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "false"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "3-for-not-one-of",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          }
+        ]
+      }
     },
     {
       "subjectKey": "mike",
       "subjectAttributes": {
         "not_one_of_flag": "false"
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "nicole",
       "subjectAttributes": {
         "null_flag": "null"
       },
-      "assignment": 5
+      "assignment": 5,
+      "assignmentDetails": {
+        "value": 5,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"5-for-matches-null\".",
+        "variationKey": "5",
+        "variationValue": 5,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "null_flag",
+              "operator": "ONE_OF",
+              "value": [
+                "null"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "5-for-matches-null",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 4
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "owen",
       "subjectAttributes": {
         "null_flag": null
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "pete",
       "subjectAttributes": {},
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-one-of",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "4-for-not-matches",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "5-for-matches-null",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -9,7 +9,41 @@
         "size": 5,
         "country": "US"
       },
-      "assignment": "small"
+      "assignment": "small",
+      "assignmentDetails": {
+        "value": "small",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"small-size\".",
+        "variationKey": "small",
+        "variationValue": "small",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "LT",
+              "value": 10
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "small-size",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "medum-size",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "large-size",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,28 +51,156 @@
         "size": 10,
         "country": "Canada"
       },
-      "assignment": "medium"
+      "assignment": "medium",
+      "assignmentDetails": {
+        "value": "medium",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"medum-size\".",
+        "variationKey": "medium",
+        "variationValue": "medium",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "GTE",
+              "value": 10
+            },
+            {
+              "attribute": "size",
+              "operator": "LTE",
+              "value": 20
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "medum-size",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "small-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "large-size",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "size": 25
       },
-      "assignment": "unknown"
+      "assignment": "unknown",
+      "assignmentDetails": {
+        "value": "unknown",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "small-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "medum-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "large-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "david",
       "subjectAttributes": {
         "size": 26
       },
-      "assignment": "large"
+      "assignment": "large",
+      "assignmentDetails": {
+        "value": "large",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"large-size\".",
+        "variationKey": "large",
+        "variationValue": "large",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "GT",
+              "value": 25
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "large-size",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "small-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "medum-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "elize",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": "unknown"
+      "assignment": "unknown",
+      "assignmentDetails": {
+        "value": "unknown",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "small-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "medum-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "large-size",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -1,32 +1,44 @@
 {
-    "flag": "comparator-operator-test",
-    "variationType": "STRING",
-    "defaultValue": "unknown",
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"size": 5, "country": "US"},
-        "assignment": "small"
+  "flag": "comparator-operator-test",
+  "variationType": "STRING",
+  "defaultValue": "unknown",
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "size": 5,
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"size": 10, "country": "Canada"},
-        "assignment": "medium"
+      "assignment": "small"
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "size": 10,
+        "country": "Canada"
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"size": 25},
-        "assignment": "unknown"
+      "assignment": "medium"
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "size": 25
       },
-      {
-        "subjectKey": "david",
-        "subjectAttributes": {"size": 26},
-        "assignment": "large"
+      "assignment": "unknown"
+    },
+    {
+      "subjectKey": "david",
+      "subjectAttributes": {
+        "size": 26
       },
-      {
-        "subjectKey": "elize",
-        "subjectAttributes": {"country": "UK"},
-        "assignment": "unknown"
-      }
-    ]
-  }
+      "assignment": "large"
+    },
+    {
+      "subjectKey": "elize",
+      "subjectAttributes": {
+        "country": "UK"
+      },
+      "assignment": "unknown"
+    }
+  ]
+}

--- a/ufc/tests/test-case-disabled-flag.json
+++ b/ufc/tests/test-case-disabled-flag.json
@@ -5,17 +5,25 @@
   "subjects": [
     {
       "subjectKey": "alice",
-      "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
       "assignment": 0
     },
     {
       "subjectKey": "bob",
-      "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
       "assignment": 0
     },
     {
       "subjectKey": "charlie",
-      "subjectAttributes": {"age": 50},
+      "subjectAttributes": {
+        "age": 50
+      },
       "assignment": 0
     }
   ]

--- a/ufc/tests/test-case-disabled-flag.json
+++ b/ufc/tests/test-case-disabled-flag.json
@@ -9,7 +9,18 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
+        "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +28,36 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
+        "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
+        "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-empty-flag.json
+++ b/ufc/tests/test-case-empty-flag.json
@@ -5,17 +5,25 @@
   "subjects": [
     {
       "subjectKey": "alice",
-      "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
       "assignment": "default_value"
     },
     {
       "subjectKey": "bob",
-      "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
       "assignment": "default_value"
     },
     {
       "subjectKey": "charlie",
-      "subjectAttributes": {"age": 50},
+      "subjectAttributes": {
+        "age": 50
+      },
       "assignment": "default_value"
     }
   ]

--- a/ufc/tests/test-case-empty-flag.json
+++ b/ufc/tests/test-case-empty-flag.json
@@ -9,7 +9,18 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": "default_value"
+      "assignment": "default_value",
+      "assignmentDetails": {
+        "value": "default_value",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +28,36 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": "default_value"
+      "assignment": "default_value",
+      "assignmentDetails": {
+        "value": "default_value",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": "default_value"
+      "assignment": "default_value",
+      "assignmentDetails": {
+        "value": "default_value",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -9,7 +9,40 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
+        "variationKey": "three",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "targeted allocation",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "50/50 split",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +50,68 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
+        "variationKey": "three",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "targeted allocation",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "50/50 split",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "debra",
@@ -33,102 +120,534 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
+        "variationKey": "three",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "targeted allocation",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "50/50 split",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "1",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "2",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "2 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "3",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "3 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "4",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "5",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "6",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "7",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "7 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "8",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "8 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "9",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "10",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "11",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "12",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "12 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "13",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "13 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "14",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "15",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "16",
       "subjectAttributes": {},
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": 2,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "17",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "18",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "19",
       "subjectAttributes": {},
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "targeted allocation",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -1,123 +1,134 @@
 {
-    "flag": "integer-flag",
-    "variationType": "INTEGER",
-    "defaultValue": 0,
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
-        "assignment": 3
+  "flag": "integer-flag",
+  "variationType": "INTEGER",
+  "defaultValue": 0,
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
-        "assignment": 3
+      "assignment": 3
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"age": 50},
-        "assignment": 2
+      "assignment": 3
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "age": 50
       },
-      {
-        "subjectKey": "debra",
-        "subjectAttributes": {"email": "test@test.com", "country": "Mexico", "age": 25},
-        "assignment": 3
+      "assignment": 2
+    },
+    {
+      "subjectKey": "debra",
+      "subjectAttributes": {
+        "email": "test@test.com",
+        "country": "Mexico",
+        "age": 25
       },
-      {
-        "subjectKey": "1",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "2",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "3",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "4",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "5",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "6",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "7",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "8",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "9",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "10",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "11",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "12",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "13",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "14",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "15",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "16",
-        "subjectAttributes": {},
-        "assignment": 2
-      },
-      {
-        "subjectKey": "17",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "18",
-        "subjectAttributes": {},
-        "assignment": 1
-      },
-      {
-        "subjectKey": "19",
-        "subjectAttributes": {},
-        "assignment": 1
-      }
-    ]
-  }
-  
+      "assignment": 3
+    },
+    {
+      "subjectKey": "1",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "2",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "3",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "4",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "5",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "6",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "7",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "8",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "9",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "10",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "11",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "12",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "13",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "14",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "15",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "16",
+      "subjectAttributes": {},
+      "assignment": 2
+    },
+    {
+      "subjectKey": "17",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "18",
+      "subjectAttributes": {},
+      "assignment": 1
+    },
+    {
+      "subjectKey": "19",
+      "subjectAttributes": {},
+      "assignment": 1
+    }
+  ]
+}

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -1,23 +1,30 @@
 {
-    "flag": "invalid-value-flag",
-    "variationType": "INTEGER",
-    "defaultValue": 42,
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
-        "assignment": 42
+  "flag": "invalid-value-flag",
+  "variationType": "INTEGER",
+  "defaultValue": 42,
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
-        "assignment": 1
+      "assignment": 42
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"age": 50},
-        "assignment": 42
-      }
-    ]
-  }
-  
+      "assignment": 1
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "age": 50
+      },
+      "assignment": 42
+    }
+  ]
+}

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -9,7 +9,29 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": 42
+      "assignment": 42,
+      "assignmentDetails": {
+        "value": 42,
+        "flagEvaluationCode": "TYPE_MISMATCH",
+        "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "valid",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 0
+          },
+          {
+            "key": "invalid",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +39,67 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"valid\".",
+        "variationKey": "one",
+        "variationValue": 1,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "Canada"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "valid",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "invalid",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": 42
+      "assignment": 42,
+      "assignmentDetails": {
+        "value": 42,
+        "flagEvaluationCode": "TYPE_MISMATCH",
+        "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "valid",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 0
+          },
+          {
+            "key": "invalid",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-kill-switch-flag.json
+++ b/ufc/tests/test-case-kill-switch-flag.json
@@ -5,22 +5,33 @@
   "subjects": [
     {
       "subjectKey": "alice",
-      "subjectAttributes": { "email": "alice@mycompany.com", "country": "US" },
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
       "assignment": true
     },
     {
       "subjectKey": "bob",
-      "subjectAttributes": { "email": "bob@example.com", "country": "Canada" },
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
       "assignment": true
     },
     {
       "subjectKey": "barbara",
-      "subjectAttributes": { "email": "barbara@example.com", "country": "canada" },
+      "subjectAttributes": {
+        "email": "barbara@example.com",
+        "country": "canada"
+      },
       "assignment": false
     },
     {
       "subjectKey": "charlie",
-      "subjectAttributes": { "age": 40 },
+      "subjectAttributes": {
+        "age": 40
+      },
       "assignment": false
     },
     {
@@ -39,42 +50,61 @@
     },
     {
       "subjectKey": "2",
-      "subjectAttributes": { "country": "Mexico" },
+      "subjectAttributes": {
+        "country": "Mexico"
+      },
       "assignment": true
     },
     {
       "subjectKey": "3",
-      "subjectAttributes": { "country": "UK", "age": 50 },
+      "subjectAttributes": {
+        "country": "UK",
+        "age": 50
+      },
       "assignment": true
     },
     {
       "subjectKey": "4",
-      "subjectAttributes": { "country": "Germany" },
+      "subjectAttributes": {
+        "country": "Germany"
+      },
       "assignment": false
     },
     {
       "subjectKey": "5",
-      "subjectAttributes": { "country": "Germany" },
+      "subjectAttributes": {
+        "country": "Germany"
+      },
       "assignment": false
     },
     {
       "subjectKey": "6",
-      "subjectAttributes": { "country": "Germany" },
+      "subjectAttributes": {
+        "country": "Germany"
+      },
       "assignment": false
     },
     {
       "subjectKey": "7",
-      "subjectAttributes": { "country": "US", "age": 12 },
+      "subjectAttributes": {
+        "country": "US",
+        "age": 12
+      },
       "assignment": true
     },
     {
       "subjectKey": "8",
-      "subjectAttributes": { "country": "Italy", "age": 60 },
+      "subjectAttributes": {
+        "country": "Italy",
+        "age": 60
+      },
       "assignment": true
     },
     {
       "subjectKey": "9",
-      "subjectAttributes": { "email": "email@email.com" },
+      "subjectAttributes": {
+        "email": "email@email.com"
+      },
       "assignment": false
     },
     {
@@ -89,12 +119,16 @@
     },
     {
       "subjectKey": "12",
-      "subjectAttributes": { "country": "US" },
+      "subjectAttributes": {
+        "country": "US"
+      },
       "assignment": true
     },
     {
       "subjectKey": "13",
-      "subjectAttributes": { "country": "Canada" },
+      "subjectAttributes": {
+        "country": "Canada"
+      },
       "assignment": true
     },
     {
@@ -104,27 +138,37 @@
     },
     {
       "subjectKey": "15",
-      "subjectAttributes": { "country": "Denmark" },
+      "subjectAttributes": {
+        "country": "Denmark"
+      },
       "assignment": false
     },
     {
       "subjectKey": "16",
-      "subjectAttributes": { "country": "Norway" },
+      "subjectAttributes": {
+        "country": "Norway"
+      },
       "assignment": false
     },
     {
       "subjectKey": "17",
-      "subjectAttributes": { "country": "UK" },
+      "subjectAttributes": {
+        "country": "UK"
+      },
       "assignment": false
     },
     {
       "subjectKey": "18",
-      "subjectAttributes": { "country": "UK" },
+      "subjectAttributes": {
+        "country": "UK"
+      },
       "assignment": false
     },
     {
       "subjectKey": "19",
-      "subjectAttributes": { "country": "UK" },
+      "subjectAttributes": {
+        "country": "UK"
+      },
       "assignment": false
     }
   ]

--- a/ufc/tests/test-case-kill-switch-flag.json
+++ b/ufc/tests/test-case-kill-switch-flag.json
@@ -9,7 +9,45 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-NA",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,7 +55,45 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-NA",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "barbara",
@@ -25,14 +101,66 @@
         "email": "barbara@example.com",
         "country": "canada"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "barbara belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 40
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "debra",
@@ -41,19 +169,121 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-NA",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "1",
       "subjectAttributes": {},
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "2",
       "subjectAttributes": {
         "country": "Mexico"
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-NA",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "3",
@@ -61,28 +291,141 @@
         "country": "UK",
         "age": 50
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "age",
+              "operator": "GTE",
+              "value": 50
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-age-50+",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "4",
       "subjectAttributes": {
         "country": "Germany"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "5",
       "subjectAttributes": {
         "country": "Germany"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "6",
       "subjectAttributes": {
         "country": "Germany"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "7",
@@ -90,7 +433,45 @@
         "country": "US",
         "age": 12
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-NA",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "8",
@@ -98,78 +479,423 @@
         "country": "Italy",
         "age": 60
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "age",
+              "operator": "GTE",
+              "value": 50
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-age-50+",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "9",
       "subjectAttributes": {
         "email": "email@email.com"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "10",
       "subjectAttributes": {},
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "11",
       "subjectAttributes": {},
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "12",
       "subjectAttributes": {
         "country": "US"
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-NA",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "13",
       "subjectAttributes": {
         "country": "Canada"
       },
-      "assignment": true
+      "assignment": true,
+      "assignmentDetails": {
+        "value": true,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
+        "variationKey": "on",
+        "variationValue": true,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "on-for-NA",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "off-for-all",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "14",
       "subjectAttributes": {},
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "15",
       "subjectAttributes": {
         "country": "Denmark"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "16",
       "subjectAttributes": {
         "country": "Norway"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "17",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "18",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "19",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": false
+      "assignment": false,
+      "assignmentDetails": {
+        "value": false,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
+        "variationKey": "off",
+        "variationValue": false,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "off-for-all",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "on-for-NA",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "on-for-age-50+",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-new-user-onboarding-flag.json
+++ b/ufc/tests/test-case-new-user-onboarding-flag.json
@@ -5,37 +5,62 @@
   "subjects": [
     {
       "subjectKey": "alice",
-      "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
       "assignment": "green"
     },
     {
       "subjectKey": "bob",
-      "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
       "assignment": "default"
     },
     {
       "subjectKey": "charlie",
-      "subjectAttributes": {"age": 50},
+      "subjectAttributes": {
+        "age": 50
+      },
       "assignment": "default"
     },
     {
       "subjectKey": "debra",
-      "subjectAttributes": {"email": "test@test.com", "country": "Mexico", "age": 25},
+      "subjectAttributes": {
+        "email": "test@test.com",
+        "country": "Mexico",
+        "age": 25
+      },
       "assignment": "blue"
     },
     {
       "subjectKey": "zach",
-      "subjectAttributes": {"email": "test@test.com", "country": "Mexico", "age": 25},
+      "subjectAttributes": {
+        "email": "test@test.com",
+        "country": "Mexico",
+        "age": 25
+      },
       "assignment": "purple"
     },
     {
       "subjectKey": "zach",
-      "subjectAttributes": {"id": "override-id", "email": "test@test.com", "country": "Mexico", "age": 25},
+      "subjectAttributes": {
+        "id": "override-id",
+        "email": "test@test.com",
+        "country": "Mexico",
+        "age": 25
+      },
       "assignment": "blue"
     },
     {
       "subjectKey": "Zach",
-      "subjectAttributes": {"email": "test@test.com", "country": "Mexico", "age": 25},
+      "subjectAttributes": {
+        "email": "test@test.com",
+        "country": "Mexico",
+        "age": 25
+      },
       "assignment": "default"
     },
     {
@@ -45,42 +70,59 @@
     },
     {
       "subjectKey": "2",
-      "subjectAttributes": {"country": "Mexico"},
+      "subjectAttributes": {
+        "country": "Mexico"
+      },
       "assignment": "blue"
     },
     {
       "subjectKey": "3",
-      "subjectAttributes": {"country": "UK", "age": 33},
+      "subjectAttributes": {
+        "country": "UK",
+        "age": 33
+      },
       "assignment": "control"
     },
     {
       "subjectKey": "4",
-      "subjectAttributes": {"country": "Germany"},
+      "subjectAttributes": {
+        "country": "Germany"
+      },
       "assignment": "red"
     },
     {
       "subjectKey": "5",
-      "subjectAttributes": {"country": "Germany"},
+      "subjectAttributes": {
+        "country": "Germany"
+      },
       "assignment": "yellow"
     },
     {
       "subjectKey": "6",
-      "subjectAttributes": {"country": "Germany"},
+      "subjectAttributes": {
+        "country": "Germany"
+      },
       "assignment": "yellow"
     },
     {
       "subjectKey": "7",
-      "subjectAttributes": {"country": "US"},
+      "subjectAttributes": {
+        "country": "US"
+      },
       "assignment": "blue"
     },
     {
       "subjectKey": "8",
-      "subjectAttributes": {"country": "Italy"},
+      "subjectAttributes": {
+        "country": "Italy"
+      },
       "assignment": "red"
     },
     {
       "subjectKey": "9",
-      "subjectAttributes": {"email": "email@email.com"},
+      "subjectAttributes": {
+        "email": "email@email.com"
+      },
       "assignment": "default"
     },
     {
@@ -95,12 +137,16 @@
     },
     {
       "subjectKey": "12",
-      "subjectAttributes": {"country": "US"},
+      "subjectAttributes": {
+        "country": "US"
+      },
       "assignment": "blue"
     },
     {
       "subjectKey": "13",
-      "subjectAttributes": {"country": "Canada"},
+      "subjectAttributes": {
+        "country": "Canada"
+      },
       "assignment": "blue"
     },
     {
@@ -110,27 +156,37 @@
     },
     {
       "subjectKey": "15",
-      "subjectAttributes": {"country": "Denmark"},
+      "subjectAttributes": {
+        "country": "Denmark"
+      },
       "assignment": "yellow"
     },
     {
       "subjectKey": "16",
-      "subjectAttributes": {"country": "Norway"},
+      "subjectAttributes": {
+        "country": "Norway"
+      },
       "assignment": "control"
     },
     {
       "subjectKey": "17",
-      "subjectAttributes": {"country": "UK"},
+      "subjectAttributes": {
+        "country": "UK"
+      },
       "assignment": "control"
     },
     {
       "subjectKey": "18",
-      "subjectAttributes": {"country": "UK"},
+      "subjectAttributes": {
+        "country": "UK"
+      },
       "assignment": "default"
     },
     {
       "subjectKey": "19",
-      "subjectAttributes": {"country": "UK"},
+      "subjectAttributes": {
+        "country": "UK"
+      },
       "assignment": "red"
     }
   ]

--- a/ufc/tests/test-case-new-user-onboarding-flag.json
+++ b/ufc/tests/test-case-new-user-onboarding-flag.json
@@ -9,7 +9,47 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": "green"
+      "assignment": "green",
+      "assignmentDetails": {
+        "value": "green",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"internal users\".",
+        "variationKey": "green",
+        "variationValue": "green",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "email",
+              "operator": "MATCHES",
+              "value": "@mycompany.com"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "internal users",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +57,78 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "debra",
@@ -33,7 +137,50 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": "blue"
+      "assignment": "blue",
+      "assignmentDetails": {
+        "value": "blue",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
+        "variationKey": "blue",
+        "variationValue": "blue",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "zach",
@@ -42,7 +189,46 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": "purple"
+      "assignment": "purple",
+      "assignmentDetails": {
+        "value": "purple",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"id rule\".",
+        "variationKey": "purple",
+        "variationValue": "purple",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "id",
+              "operator": "MATCHES",
+              "value": "zach"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "id rule",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "zach",
@@ -52,7 +238,50 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": "blue"
+      "assignment": "blue",
+      "assignmentDetails": {
+        "value": "blue",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
+        "variationKey": "blue",
+        "variationValue": "blue",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "Zach",
@@ -61,19 +290,126 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "1",
       "subjectAttributes": {},
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "2",
       "subjectAttributes": {
         "country": "Mexico"
       },
-      "assignment": "blue"
+      "assignment": "blue",
+      "assignmentDetails": {
+        "value": "blue",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
+        "variationKey": "blue",
+        "variationValue": "blue",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "3",
@@ -81,113 +417,798 @@
         "country": "UK",
         "age": 33
       },
-      "assignment": "control"
+      "assignment": "control",
+      "assignmentDetails": {
+        "value": "control",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 3 belongs to the range of traffic assigned to \"control\".",
+        "variationKey": "control",
+        "variationValue": "control",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "4",
       "subjectAttributes": {
         "country": "Germany"
       },
-      "assignment": "red"
+      "assignment": "red",
+      "assignmentDetails": {
+        "value": "red",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 4 belongs to the range of traffic assigned to \"red\".",
+        "variationKey": "red",
+        "variationValue": "red",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "5",
       "subjectAttributes": {
         "country": "Germany"
       },
-      "assignment": "yellow"
+      "assignment": "yellow",
+      "assignmentDetails": {
+        "value": "yellow",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 5 belongs to the range of traffic assigned to \"yellow\".",
+        "variationKey": "yellow",
+        "variationValue": "yellow",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "6",
       "subjectAttributes": {
         "country": "Germany"
       },
-      "assignment": "yellow"
+      "assignment": "yellow",
+      "assignmentDetails": {
+        "value": "yellow",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 6 belongs to the range of traffic assigned to \"yellow\".",
+        "variationKey": "yellow",
+        "variationValue": "yellow",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "7",
       "subjectAttributes": {
         "country": "US"
       },
-      "assignment": "blue"
+      "assignment": "blue",
+      "assignmentDetails": {
+        "value": "blue",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
+        "variationKey": "blue",
+        "variationValue": "blue",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "8",
       "subjectAttributes": {
         "country": "Italy"
       },
-      "assignment": "red"
+      "assignment": "red",
+      "assignmentDetails": {
+        "value": "red",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 8 belongs to the range of traffic assigned to \"red\".",
+        "variationKey": "red",
+        "variationValue": "red",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "9",
       "subjectAttributes": {
         "email": "email@email.com"
       },
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "10",
       "subjectAttributes": {},
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "11",
       "subjectAttributes": {},
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "12",
       "subjectAttributes": {
         "country": "US"
       },
-      "assignment": "blue"
+      "assignment": "blue",
+      "assignmentDetails": {
+        "value": "blue",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
+        "variationKey": "blue",
+        "variationValue": "blue",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "13",
       "subjectAttributes": {
         "country": "Canada"
       },
-      "assignment": "blue"
+      "assignment": "blue",
+      "assignmentDetails": {
+        "value": "blue",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
+        "variationKey": "blue",
+        "variationValue": "blue",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "14",
       "subjectAttributes": {},
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "15",
       "subjectAttributes": {
         "country": "Denmark"
       },
-      "assignment": "yellow"
+      "assignment": "yellow",
+      "assignmentDetails": {
+        "value": "yellow",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 15 belongs to the range of traffic assigned to \"yellow\".",
+        "variationKey": "yellow",
+        "variationValue": "yellow",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "16",
       "subjectAttributes": {
         "country": "Norway"
       },
-      "assignment": "control"
+      "assignment": "control",
+      "assignmentDetails": {
+        "value": "control",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 16 belongs to the range of traffic assigned to \"control\".",
+        "variationKey": "control",
+        "variationValue": "control",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "17",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": "control"
+      "assignment": "control",
+      "assignmentDetails": {
+        "value": "control",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 17 belongs to the range of traffic assigned to \"control\".",
+        "variationKey": "control",
+        "variationValue": "control",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     },
     {
       "subjectKey": "18",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": "default"
+      "assignment": "default",
+      "assignmentDetails": {
+        "value": "default",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "experiment",
+            "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
+            "orderPosition": 2
+          },
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "19",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": "red"
+      "assignment": "red",
+      "assignmentDetails": {
+        "value": "red",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 19 belongs to the range of traffic assigned to \"red\".",
+        "variationKey": "red",
+        "variationValue": "red",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "country",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "US",
+                "Canada",
+                "Mexico"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "experiment",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "id rule",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "internal users",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "rollout",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          }
+        ]
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-no-allocations-flag.json
+++ b/ufc/tests/test-case-no-allocations-flag.json
@@ -1,22 +1,38 @@
 {
   "flag": "no_allocations_flag",
   "variationType": "JSON",
-  "defaultValue": {"hello": "world"},
+  "defaultValue": {
+    "hello": "world"
+  },
   "subjects": [
     {
       "subjectKey": "alice",
-      "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
-      "assignment": {"hello": "world"}
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
+      "assignment": {
+        "hello": "world"
+      }
     },
     {
       "subjectKey": "bob",
-      "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
-      "assignment": {"hello": "world"}
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
+      "assignment": {
+        "hello": "world"
+      }
     },
     {
       "subjectKey": "charlie",
-      "subjectAttributes": {"age": 50},
-      "assignment": {"hello": "world"}
+      "subjectAttributes": {
+        "age": 50
+      },
+      "assignment": {
+        "hello": "world"
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-no-allocations-flag.json
+++ b/ufc/tests/test-case-no-allocations-flag.json
@@ -13,6 +13,19 @@
       },
       "assignment": {
         "hello": "world"
+      },
+      "assignmentDetails": {
+        "value": {
+          "hello": "world"
+        },
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     },
     {
@@ -23,6 +36,19 @@
       },
       "assignment": {
         "hello": "world"
+      },
+      "assignmentDetails": {
+        "value": {
+          "hello": "world"
+        },
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     },
     {
@@ -32,6 +58,19 @@
       },
       "assignment": {
         "hello": "world"
+      },
+      "assignmentDetails": {
+        "value": {
+          "hello": "world"
+        },
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     }
   ]

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -9,7 +9,36 @@
         "size": 5,
         "country": "US"
       },
-      "assignment": "old"
+      "assignment": "old",
+      "assignmentDetails": {
+        "value": "old",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
+        "variationKey": "old",
+        "variationValue": "old",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "LT",
+              "value": 10
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "null-operator",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "not-null-operator",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,28 +46,144 @@
         "size": 10,
         "country": "Canada"
       },
-      "assignment": "new"
+      "assignment": "new",
+      "assignmentDetails": {
+        "value": "new",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
+        "variationKey": "new",
+        "variationValue": "new",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "IS_NULL",
+              "value": false
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "not-null-operator",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "null-operator",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "size": null
       },
-      "assignment": "old"
+      "assignment": "old",
+      "assignmentDetails": {
+        "value": "old",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
+        "variationKey": "old",
+        "variationValue": "old",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "IS_NULL",
+              "value": true
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "null-operator",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "not-null-operator",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "david",
       "subjectAttributes": {
         "size": 26
       },
-      "assignment": "new"
+      "assignment": "new",
+      "assignmentDetails": {
+        "value": "new",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
+        "variationKey": "new",
+        "variationValue": "new",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "IS_NULL",
+              "value": false
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "not-null-operator",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "null-operator",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "elize",
       "subjectAttributes": {
         "country": "UK"
       },
-      "assignment": "old"
+      "assignment": "old",
+      "assignmentDetails": {
+        "value": "old",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
+        "variationKey": "old",
+        "variationValue": "old",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "size",
+              "operator": "IS_NULL",
+              "value": true
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "null-operator",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "not-null-operator",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -1,32 +1,44 @@
 {
-    "flag": "null-operator-test",
-    "variationType": "STRING",
-    "defaultValue": "default-null",
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"size": 5, "country": "US"},
-        "assignment": "old"
+  "flag": "null-operator-test",
+  "variationType": "STRING",
+  "defaultValue": "default-null",
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "size": 5,
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"size": 10, "country": "Canada"},
-        "assignment": "new"
+      "assignment": "old"
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "size": 10,
+        "country": "Canada"
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"size": null},
-        "assignment": "old"
+      "assignment": "new"
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "size": null
       },
-      {
-        "subjectKey": "david",
-        "subjectAttributes": {"size": 26},
-        "assignment": "new"
+      "assignment": "old"
+    },
+    {
+      "subjectKey": "david",
+      "subjectAttributes": {
+        "size": 26
       },
-      {
-        "subjectKey": "elize",
-        "subjectAttributes": {"country": "UK"},
-        "assignment": "old"
-      }
-    ]
-  }
+      "assignment": "new"
+    },
+    {
+      "subjectKey": "elize",
+      "subjectAttributes": {
+        "country": "UK"
+      },
+      "assignment": "old"
+    }
+  ]
+}

--- a/ufc/tests/test-case-numeric-flag.json
+++ b/ufc/tests/test-case-numeric-flag.json
@@ -9,7 +9,22 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": 3.1415926
+      "assignment": 3.1415926,
+      "assignmentDetails": {
+        "value": 3.1415926,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
+        "variationKey": "pi",
+        "variationValue": 3.1415926,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +32,44 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": 3.1415926
+      "assignment": 3.1415926,
+      "assignmentDetails": {
+        "value": 3.1415926,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
+        "variationKey": "pi",
+        "variationValue": 3.1415926,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": 3.1415926
+      "assignment": 3.1415926,
+      "assignmentDetails": {
+        "value": 3.1415926,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
+        "variationKey": "pi",
+        "variationValue": 3.1415926,
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "rollout",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-numeric-flag.json
+++ b/ufc/tests/test-case-numeric-flag.json
@@ -1,21 +1,29 @@
 {
   "flag": "numeric_flag",
   "variationType": "NUMERIC",
-  "defaultValue": 0.0,
+  "defaultValue": 0,
   "subjects": [
     {
       "subjectKey": "alice",
-      "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
       "assignment": 3.1415926
     },
     {
       "subjectKey": "bob",
-      "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
       "assignment": 3.1415926
     },
     {
       "subjectKey": "charlie",
-      "subjectAttributes": {"age": 50},
+      "subjectAttributes": {
+        "age": 50
+      },
       "assignment": 3.1415926
     }
   ]

--- a/ufc/tests/test-case-numeric-one-of.json
+++ b/ufc/tests/test-case-numeric-one-of.json
@@ -1,43 +1,56 @@
 {
-    "flag": "numeric-one-of",
-    "variationType": "INTEGER",
-    "defaultValue": 0,
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"number": 1},
-        "assignment": 1
+  "flag": "numeric-one-of",
+  "variationType": "INTEGER",
+  "defaultValue": 0,
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "number": 1
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"number": 2 },
-        "assignment": 0
+      "assignment": 1
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "number": 2
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"number": 3},
-        "assignment": 3
+      "assignment": 0
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "number": 3
       },
-      {
-        "subjectKey": "derek",
-        "subjectAttributes": {"number": 4},
-        "assignment": 3
+      "assignment": 3
+    },
+    {
+      "subjectKey": "derek",
+      "subjectAttributes": {
+        "number": 4
       },
-      {
-        "subjectKey": "erica",
-        "subjectAttributes": {"number": "1"},
-        "assignment": 1
+      "assignment": 3
+    },
+    {
+      "subjectKey": "erica",
+      "subjectAttributes": {
+        "number": "1"
       },
-      {
-        "subjectKey": "frank",
-        "subjectAttributes": {"number": 1.0},
-        "assignment": 1
+      "assignment": 1
+    },
+    {
+      "subjectKey": "frank",
+      "subjectAttributes": {
+        "number": 1
       },
-      {
-        "subjectKey": "george",
-        "subjectAttributes": {"number": 123456789.0},
-        "assignment": 2
-      }
-    ]
-  }
-
+      "assignment": 1
+    },
+    {
+      "subjectKey": "george",
+      "subjectAttributes": {
+        "number": 123456789
+      },
+      "assignment": 2
+    }
+  ]
+}

--- a/ufc/tests/test-case-numeric-one-of.json
+++ b/ufc/tests/test-case-numeric-one-of.json
@@ -8,49 +8,293 @@
       "subjectAttributes": {
         "number": 1
       },
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
+        "variationKey": "1",
+        "variationValue": 1,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "number",
+              "operator": "ONE_OF",
+              "value": [
+                "1"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "1-for-1",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "2-for-123456789",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-2",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
       "subjectAttributes": {
         "number": 2
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-1",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-123456789",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-2",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "number": 3
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
+        "variationKey": "3",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "number",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "2"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "3-for-not-2",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-1",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-123456789",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "derek",
       "subjectAttributes": {
         "number": 4
       },
-      "assignment": 3
+      "assignment": 3,
+      "assignmentDetails": {
+        "value": 3,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
+        "variationKey": "3",
+        "variationValue": 3,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "number",
+              "operator": "NOT_ONE_OF",
+              "value": [
+                "2"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "3-for-not-2",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-1",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "2-for-123456789",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "erica",
       "subjectAttributes": {
         "number": "1"
       },
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
+        "variationKey": "1",
+        "variationValue": 1,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "number",
+              "operator": "ONE_OF",
+              "value": [
+                "1"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "1-for-1",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "2-for-123456789",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-2",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "frank",
       "subjectAttributes": {
         "number": 1
       },
-      "assignment": 1
+      "assignment": 1,
+      "assignmentDetails": {
+        "value": 1,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
+        "variationKey": "1",
+        "variationValue": 1,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "number",
+              "operator": "ONE_OF",
+              "value": [
+                "1"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "1-for-1",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "2-for-123456789",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "3-for-not-2",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "george",
       "subjectAttributes": {
         "number": 123456789
       },
-      "assignment": 2
+      "assignment": 2,
+      "assignmentDetails": {
+        "value": 2,
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-123456789\".",
+        "variationKey": "2",
+        "variationValue": 2,
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "number",
+              "operator": "ONE_OF",
+              "value": [
+                "123456789"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "2-for-123456789",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "1-for-1",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "3-for-not-2",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-regex-flag.json
+++ b/ufc/tests/test-case-regex-flag.json
@@ -1,27 +1,38 @@
 {
-    "flag": "regex-flag",
-    "variationType": "STRING",
-    "defaultValue": "none",
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"version": "1.15.0", "email": "alice@example.com"},
-        "assignment": "partial-example"
+  "flag": "regex-flag",
+  "variationType": "STRING",
+  "defaultValue": "none",
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "version": "1.15.0",
+        "email": "alice@example.com"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"version": "0.20.1", "email": "bob@test.com"},
-        "assignment": "test"
+      "assignment": "partial-example"
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "version": "0.20.1",
+        "email": "bob@test.com"
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"version": "2.1.13"},
-        "assignment": "none"
+      "assignment": "test"
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "version": "2.1.13"
       },
-      {
-        "subjectKey": "derek",
-        "subjectAttributes": {"version": "2.1.13", "email": "derek@gmail.com"},
-        "assignment": "none"
-      }
-    ]
-  }
+      "assignment": "none"
+    },
+    {
+      "subjectKey": "derek",
+      "subjectAttributes": {
+        "version": "2.1.13",
+        "email": "derek@gmail.com"
+      },
+      "assignment": "none"
+    }
+  ]
+}

--- a/ufc/tests/test-case-regex-flag.json
+++ b/ufc/tests/test-case-regex-flag.json
@@ -9,7 +9,36 @@
         "version": "1.15.0",
         "email": "alice@example.com"
       },
-      "assignment": "partial-example"
+      "assignment": "partial-example",
+      "assignmentDetails": {
+        "value": "partial-example",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"partial-example\".",
+        "variationKey": "partial-example",
+        "variationValue": "partial-example",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "email",
+              "operator": "MATCHES",
+              "value": "@example\\.com"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "partial-example",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "test",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +46,65 @@
         "version": "0.20.1",
         "email": "bob@test.com"
       },
-      "assignment": "test"
+      "assignment": "test",
+      "assignmentDetails": {
+        "value": "test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"test\".",
+        "variationKey": "test",
+        "variationValue": "test",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "email",
+              "operator": "MATCHES",
+              "value": ".*@test\\.com"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "test",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "partial-example",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "version": "2.1.13"
       },
-      "assignment": "none"
+      "assignment": "none",
+      "assignmentDetails": {
+        "value": "none",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "partial-example",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "test",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "derek",
@@ -32,7 +112,29 @@
         "version": "2.1.13",
         "email": "derek@gmail.com"
       },
-      "assignment": "none"
+      "assignment": "none",
+      "assignmentDetails": {
+        "value": "none",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "partial-example",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "test",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -1,37 +1,51 @@
 {
-    "flag": "semver-test",
-    "variationType": "STRING",
-    "defaultValue": "unknown",
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"version": "1.15.0", "country": "US"},
-        "assignment": "current"
+  "flag": "semver-test",
+  "variationType": "STRING",
+  "defaultValue": "unknown",
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "version": "1.15.0",
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"version": "0.20.1", "country": "Canada"},
-        "assignment": "old"
+      "assignment": "current"
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "version": "0.20.1",
+        "country": "Canada"
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"version": "2.1.13"},
-        "assignment": "current"
+      "assignment": "old"
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "version": "2.1.13"
       },
-      {
-        "subjectKey": "david",
-        "subjectAttributes": {"version": "3.1.0"},
-        "assignment": "unknown"
+      "assignment": "current"
+    },
+    {
+      "subjectKey": "david",
+      "subjectAttributes": {
+        "version": "3.1.0"
       },
-      {
-        "subjectKey": "elize",
-        "subjectAttributes": {"version": "3.1.1"},
-        "assignment": "new"
+      "assignment": "unknown"
+    },
+    {
+      "subjectKey": "elize",
+      "subjectAttributes": {
+        "version": "3.1.1"
       },
-      {
-        "subjectKey": "frank",
-        "subjectAttributes": {"version": "1.5.0"},
-        "assignment": "current"
-      }
-    ]
-  }
+      "assignment": "new"
+    },
+    {
+      "subjectKey": "frank",
+      "subjectAttributes": {
+        "version": "1.5.0"
+      },
+      "assignment": "current"
+    }
+  ]
+}

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -9,7 +9,47 @@
         "version": "1.15.0",
         "country": "US"
       },
-      "assignment": "current"
+      "assignment": "current",
+      "assignmentDetails": {
+        "value": "current",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
+        "variationKey": "current",
+        "variationValue": "current",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "version",
+              "operator": "GTE",
+              "value": "1.5.0"
+            },
+            {
+              "attribute": "version",
+              "operator": "LTE",
+              "value": "2.2.13"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "current-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "new-versions",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,35 +57,210 @@
         "version": "0.20.1",
         "country": "Canada"
       },
-      "assignment": "old"
+      "assignment": "old",
+      "assignmentDetails": {
+        "value": "old",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"old-versions\".",
+        "variationKey": "old",
+        "variationValue": "old",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "version",
+              "operator": "LT",
+              "value": "1.5.0"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "old-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "current-versions",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 1
+          },
+          {
+            "key": "new-versions",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "version": "2.1.13"
       },
-      "assignment": "current"
+      "assignment": "current",
+      "assignmentDetails": {
+        "value": "current",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
+        "variationKey": "current",
+        "variationValue": "current",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "version",
+              "operator": "GTE",
+              "value": "1.5.0"
+            },
+            {
+              "attribute": "version",
+              "operator": "LTE",
+              "value": "2.2.13"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "current-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "new-versions",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     },
     {
       "subjectKey": "david",
       "subjectAttributes": {
         "version": "3.1.0"
       },
-      "assignment": "unknown"
+      "assignment": "unknown",
+      "assignmentDetails": {
+        "value": "unknown",
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "current-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "new-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "elize",
       "subjectAttributes": {
         "version": "3.1.1"
       },
-      "assignment": "new"
+      "assignment": "new",
+      "assignmentDetails": {
+        "value": "new",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"new-versions\".",
+        "variationKey": "new",
+        "variationValue": "new",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "version",
+              "operator": "GT",
+              "value": "3.1.0"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "new-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          },
+          {
+            "key": "current-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "frank",
       "subjectAttributes": {
         "version": "1.5.0"
       },
-      "assignment": "current"
+      "assignment": "current",
+      "assignmentDetails": {
+        "value": "current",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
+        "variationKey": "current",
+        "variationValue": "current",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "version",
+              "operator": "GTE",
+              "value": "1.5.0"
+            },
+            {
+              "attribute": "version",
+              "operator": "LTE",
+              "value": "2.2.13"
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "current-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 0
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "new-versions",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -9,7 +9,33 @@
         "version": "1.15.0",
         "country": "US"
       },
-      "assignment": "current"
+      "assignment": "current",
+      "assignmentDetails": {
+        "value": "current",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
+        "variationKey": "current",
+        "variationValue": "current",
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "current-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "AFTER_END_TIME",
+            "orderPosition": 0
+          },
+          {
+            "key": "future-versions",
+            "allocationEvaluationCode": "BEFORE_START_TIME",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +43,66 @@
         "version": "0.20.1",
         "country": "Canada"
       },
-      "assignment": "current"
+      "assignment": "current",
+      "assignmentDetails": {
+        "value": "current",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
+        "variationKey": "current",
+        "variationValue": "current",
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "current-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "AFTER_END_TIME",
+            "orderPosition": 0
+          },
+          {
+            "key": "future-versions",
+            "allocationEvaluationCode": "BEFORE_START_TIME",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "version": "2.1.13"
       },
-      "assignment": "current"
+      "assignment": "current",
+      "assignmentDetails": {
+        "value": "current",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
+        "variationKey": "current",
+        "variationValue": "current",
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "current-versions",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "old-versions",
+            "allocationEvaluationCode": "AFTER_END_TIME",
+            "orderPosition": 0
+          },
+          {
+            "key": "future-versions",
+            "allocationEvaluationCode": "BEFORE_START_TIME",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -1,22 +1,30 @@
 {
-    "flag": "start-and-end-date-test",
-    "variationType": "STRING",
-    "defaultValue": "unknown",
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"version": "1.15.0", "country": "US"},
-        "assignment": "current"
+  "flag": "start-and-end-date-test",
+  "variationType": "STRING",
+  "defaultValue": "unknown",
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "version": "1.15.0",
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"version": "0.20.1", "country": "Canada"},
-        "assignment": "current"
+      "assignment": "current"
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "version": "0.20.1",
+        "country": "Canada"
       },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"version": "2.1.13"},
-        "assignment": "current"
-      }
-    ]
+      "assignment": "current"
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "version": "2.1.13"
+      },
+      "assignment": "current"
+    }
+  ]
 }

--- a/ufc/tests/test-flag-that-does-not-exist.json
+++ b/ufc/tests/test-flag-that-does-not-exist.json
@@ -1,22 +1,30 @@
 {
   "flag": "flag-that-does-not-exist",
   "variationType": "NUMERIC",
-  "defaultValue": 0.0,
+  "defaultValue": 0,
   "subjects": [
     {
       "subjectKey": "alice",
-      "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
-      "assignment": 0.0
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
+      "assignment": 0
     },
     {
       "subjectKey": "bob",
-      "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
-      "assignment": 0.0
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
+      "assignment": 0
     },
     {
       "subjectKey": "charlie",
-      "subjectAttributes": {"age": 50},
-      "assignment": 0.0
+      "subjectAttributes": {
+        "age": 50
+      },
+      "assignment": 0
     }
   ]
 }

--- a/ufc/tests/test-flag-that-does-not-exist.json
+++ b/ufc/tests/test-flag-that-does-not-exist.json
@@ -9,7 +9,18 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
+        "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "bob",
@@ -17,14 +28,36 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
+        "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     },
     {
       "subjectKey": "charlie",
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": 0
+      "assignment": 0,
+      "assignmentDetails": {
+        "value": 0,
+        "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
+        "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
     }
   ]
 }

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -1,22 +1,42 @@
 {
-    "flag": "json-config-flag",
-    "variationType": "JSON",
-    "defaultValue": {},
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
-        "assignment": { "integer": 1, "string": "one", "float": 1.0 }
+  "flag": "json-config-flag",
+  "variationType": "JSON",
+  "defaultValue": {},
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
-        "assignment": { "integer": 2, "string": "two", "float": 2.0 }
-      },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"age": 50},
-        "assignment": { "integer": 2, "string": "two", "float": 2.0 }
+      "assignment": {
+        "integer": 1,
+        "string": "one",
+        "float": 1
       }
-    ]
-  }
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
+      "assignment": {
+        "integer": 2,
+        "string": "two",
+        "float": 2
+      }
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "age": 50
+      },
+      "assignment": {
+        "integer": 2,
+        "string": "two",
+        "float": 2
+      }
+    }
+  ]
+}

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -13,6 +13,25 @@
         "integer": 1,
         "string": "one",
         "float": 1
+      },
+      "assignmentDetails": {
+        "value": {
+          "integer": 1,
+          "string": "one",
+          "float": 1
+        },
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "variationKey": "one",
+        "variationValue": "{ \"integer\": 1, \"string\": \"one\", \"float\": 1.0 }",
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     },
     {
@@ -25,6 +44,25 @@
         "integer": 2,
         "string": "two",
         "float": 2
+      },
+      "assignmentDetails": {
+        "value": {
+          "integer": 2,
+          "string": "two",
+          "float": 2
+        },
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": "{ \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }",
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     },
     {
@@ -36,6 +74,25 @@
         "integer": 2,
         "string": "two",
         "float": 2
+      },
+      "assignmentDetails": {
+        "value": {
+          "integer": 2,
+          "string": "two",
+          "float": 2
+        },
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "variationKey": "two",
+        "variationValue": "{ \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }",
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 0
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     }
   ]

--- a/ufc/tests/test-no-allocations-flag.json
+++ b/ufc/tests/test-no-allocations-flag.json
@@ -1,22 +1,38 @@
 {
-    "flag": "no_allocations_flag",
-    "variationType": "JSON",
-    "defaultValue": {"message": "Hello, world!"},
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"email": "alice@mycompany.com", "country": "US"},
-        "assignment": {"message": "Hello, world!"}
+  "flag": "no_allocations_flag",
+  "variationType": "JSON",
+  "defaultValue": {
+    "message": "Hello, world!"
+  },
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
       },
-      {
-        "subjectKey": "bob",
-        "subjectAttributes": {"email": "bob@example.com", "country": "Canada"},
-        "assignment": {"message": "Hello, world!"}
-      },
-      {
-        "subjectKey": "charlie",
-        "subjectAttributes": {"age": 50},
-        "assignment": {"message": "Hello, world!"}
+      "assignment": {
+        "message": "Hello, world!"
       }
-    ]
-  }
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
+      "assignment": {
+        "message": "Hello, world!"
+      }
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "age": 50
+      },
+      "assignment": {
+        "message": "Hello, world!"
+      }
+    }
+  ]
+}

--- a/ufc/tests/test-no-allocations-flag.json
+++ b/ufc/tests/test-no-allocations-flag.json
@@ -13,6 +13,19 @@
       },
       "assignment": {
         "message": "Hello, world!"
+      },
+      "assignmentDetails": {
+        "value": {
+          "message": "Hello, world!"
+        },
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     },
     {
@@ -23,6 +36,19 @@
       },
       "assignment": {
         "message": "Hello, world!"
+      },
+      "assignmentDetails": {
+        "value": {
+          "message": "Hello, world!"
+        },
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     },
     {
@@ -32,6 +58,19 @@
       },
       "assignment": {
         "message": "Hello, world!"
+      },
+      "assignmentDetails": {
+        "value": {
+          "message": "Hello, world!"
+        },
+        "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
+        "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
+        "variationKey": null,
+        "variationValue": null,
+        "matchedRule": null,
+        "matchedAllocation": null,
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
       }
     }
   ]


### PR DESCRIPTION
updates existing test data to support new "assignment details" which provide end-users information on how an assignment happened

- first commit is just formatting changes
- second commit adds new "assignmentDetails" object