### PR TITLE
Update test-json-config-flag.json assignments to match actual.

### DIFF
--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -12,7 +12,7 @@
       "assignment": {
         "integer": 1,
         "string": "one",
-        "float": 1
+        "float": 1.0
       },
       "assignmentDetails": {
         "value": {
@@ -43,7 +43,7 @@
       "assignment": {
         "integer": 2,
         "string": "two",
-        "float": 2
+        "float": 2.0
       },
       "assignmentDetails": {
         "value": {
@@ -73,7 +73,7 @@
       "assignment": {
         "integer": 2,
         "string": "two",
-        "float": 2
+        "float": 2.0
       },
       "assignmentDetails": {
         "value": {


### PR DESCRIPTION
[pr/30](https://github.com/Eppo-exp/sdk-test-data/pull/30) broke tests in at least the .NET SDK. Here, the expected JSON doesn't match the assigned JSON exactly - they're technically equivalent if you do some numeric processing on the values, but we shouldn't really be doing additional processing on this encoded data.