### PR TITLE
Add test cases for numbers passed as categorical attributes

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -17,7 +17,8 @@
                         "variationKey": "control",
                         "shards": []
                     }
-                ]
+                ],
+                "doLog": true
             }
         ]
       },
@@ -37,7 +38,8 @@
                         "variationKey": "control",
                         "shards": []
                     }
-                ]
+                ],
+                "doLog": true
             }
         ]
       },
@@ -79,7 +81,8 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "doLog": true
             },
             {
                 "key": "training",
@@ -93,7 +96,8 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "doLog": false
             }
         ],
         "totalShards": 10000
@@ -127,7 +131,8 @@
                         "variationKey": "banner_bandit",
                         "shards": []
                     }
-                ]
+                ],
+                "doLog": true
             },
             {
                 "key": "default",
@@ -137,7 +142,8 @@
                         "variationKey": "control",
                         "shards": []
                     }
-                ]
+                ],
+                "doLog": true
             }
         ],
         "totalShards": 10000

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -82,7 +82,7 @@
                         ]
                     }
                 ],
-                "doLog": true
+                "doLog": false
             },
             {
                 "key": "training",
@@ -97,7 +97,7 @@
                         ]
                     }
                 ],
-                "doLog": false
+                "doLog": true
             }
         ],
         "totalShards": 10000

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -1,6 +1,6 @@
 {
   "updatedAt": "2023-09-13T04:52:06.462Z",
-  "bandits": { 
+  "bandits": {
     "banner_bandit": {
       "banditKey": "banner_bandit",
       "modelName": "falcon",
@@ -28,6 +28,15 @@
                    "gold": 4.5,
                    "silver":  3.2,
                    "bronze":  1.9
+                },
+                "missingValueCoefficient": 0.0
+              },
+              {
+                "attributeKey": "area_code",
+                "valueCoefficients": {
+                  "303": 10.0,
+                  "301":  7.0,
+                  "415":  -2.0
                 },
                 "missingValueCoefficient": 0.0
               }

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -32,11 +32,11 @@
                 "missingValueCoefficient": 0.0
               },
               {
-                "attributeKey": "area_code",
+                "attributeKey": "zip",
                 "valueCoefficients": {
-                  "303": 10.0,
-                  "301":  7.0,
-                  "415":  -2.0
+                  "22203": 5.0,
+                  "94111": -10.0,
+                  "81427": 8.0
                 },
                 "missingValueCoefficient": 0.0
               }
@@ -88,6 +88,15 @@
                   "male": 0.3
                 },
                 "missingValueCoefficient": 0.45
+              },
+              {
+                "attributeKey": "area_code",
+                "valueCoefficients": {
+                  "303": 10.0,
+                  "301": 7.0,
+                  "415": -2.0
+                },
+                "missingValueCoefficient": 0.0
               }
             ]
           }

--- a/ufc/bandit-tests/test-case-bandit-does-not-exist.json
+++ b/ufc/bandit-tests/test-case-bandit-does-not-exist.json
@@ -4,7 +4,7 @@
     "subjects": [
       {
         "subjectKey": "alice",
-        "subjectAttributes": {"numeric_attributes": {"age": 25}, "categorical_attributes": {"country": "USA"}},
+        "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
         "actions": [],
         "assignment": {"variation": "default", "action": null}
       }

--- a/ufc/bandit-tests/test-case-bandit-no-actions.json
+++ b/ufc/bandit-tests/test-case-bandit-no-actions.json
@@ -4,7 +4,7 @@
     "subjects": [
       {
         "subjectKey": "alice",
-        "subjectAttributes": {"numeric_attributes": {"age": 25}, "categorical_attributes": {"country": "USA"}},
+        "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
         "actions": [],
         "assignment": {"variation": "default", "action": null}
       }

--- a/ufc/bandit-tests/test-case-banner-bandit-uk-only.json
+++ b/ufc/bandit-tests/test-case-banner-bandit-uk-only.json
@@ -5,8 +5,8 @@
       {
         "subjectKey": "alice",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 25}, 
-            "categorical_attributes": {"country": "USA", "gender_identity": "female"}
+            "numericAttributes": {"age": 25},
+            "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
         },
         "actions": [
             {
@@ -31,8 +31,8 @@
       {
         "subjectKey": "bob",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 30, "account_age": 10}, 
-            "categorical_attributes": {"country": "UK", "gender_identity": "male"}
+            "numericAttributes": {"age": 30, "account_age": 10},
+            "categoricalAttributes": {"country": "UK", "gender_identity": "male"}
         },
         "actions": [
             {
@@ -57,8 +57,8 @@
       {
         "subjectKey": "charlie",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 50, "account_age": 2}, 
-            "categorical_attributes": {"country": "Canada", "gender_identity": "unknown"}
+            "numericAttributes": {"age": 50, "account_age": 2},
+            "categoricalAttributes": {"country": "Canada", "gender_identity": "unknown"}
         },
         "actions": [
             {
@@ -83,8 +83,8 @@
       {
         "subjectKey": "debra",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 28, "account_age": 30}, 
-            "categorical_attributes": {"country": "UK", "gender_identity": "unknown"}
+            "numericAttributes": {"age": 28, "account_age": 30},
+            "categoricalAttributes": {"country": "UK", "gender_identity": "unknown"}
         },
         "actions": [
             {
@@ -109,8 +109,8 @@
       {
         "subjectKey": "erica",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 28, "account_age": 30}, 
-            "categorical_attributes": {"country": "USA", "gender_identity": "female"}
+            "numericAttributes": {"age": 28, "account_age": 30},
+            "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
         },
         "actions": [
             {
@@ -145,8 +145,8 @@
       {
         "subjectKey": "frenkie",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 31, "account_age": 4}, 
-            "categorical_attributes": {"country": "Netherlands", "gender_identity": "male"}
+            "numericAttributes": {"age": 31, "account_age": 4},
+            "categoricalAttributes": {"country": "Netherlands", "gender_identity": "male"}
         },
         "actions": [
             {
@@ -180,8 +180,8 @@
       {
         "subjectKey": "gerard",
         "subjectAttributes": {
-            "numeric_attributes": {"age": null}, 
-            "categorical_attributes": {"country": null, "gender_identity": null}
+            "numericAttributes": {"age": null},
+            "categoricalAttributes": {"country": null, "gender_identity": null}
         },
         "actions": [
             {

--- a/ufc/bandit-tests/test-case-banner-bandit.json
+++ b/ufc/bandit-tests/test-case-banner-bandit.json
@@ -211,6 +211,56 @@
             }
         ],
         "assignment": {"variation": "banner_bandit", "action": "nike"}
+      },
+      {
+        "subjectKey": "henry",
+        "subjectAttributes": {
+          "numericAttributes": { "age": 25, "mistake": "oops" },
+          "categoricalAttributes": {"country": "USA", "gender_identity": "female", "area_code": 303}
+        },
+        "actions": [
+          {
+            "actionKey": "nike",
+            "numericAttributes": {"brand_affinity": -5},
+            "categoricalAttributes": {"loyalty_tier": "silver"}
+          },
+          {
+            "actionKey": "adidas",
+            "numericAttributes": {"brand_affinity": 1.0},
+            "categoricalAttributes": {"loyalty_tier": "bronze"}
+          },
+          {
+            "actionKey": "reebok",
+            "numericAttributes": {"brand_affinity": 20},
+            "categoricalAttributes": {"loyalty_tier": "gold"}
+          }
+        ],
+        "assignment": {"variation": "banner_bandit", "action": "adidas"}
+      },
+      {
+        "subjectKey": "imogene",
+        "subjectAttributes": {
+          "numericAttributes": { "age": 25},
+          "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
+        },
+        "actions": [
+          {
+            "actionKey": "nike",
+            "numericAttributes": {"brand_affinity": -1.7, "mistake": true},
+            "categoricalAttributes": {"loyalty_tier": "silver", "zip":  81427}
+          },
+          {
+            "actionKey": "adidas",
+            "numericAttributes": {"brand_affinity": 1.0},
+            "categoricalAttributes": {"loyalty_tier": "bronze"}
+          },
+          {
+            "actionKey": "reebok",
+            "numericAttributes": {"brand_affinity": 15},
+            "categoricalAttributes": {"loyalty_tier": "gold"}
+          }
+        ],
+        "assignment": {"variation": "banner_bandit", "action": "nike"}
       }
     ]
   }

--- a/ufc/bandit-tests/test-case-banner-bandit.json
+++ b/ufc/bandit-tests/test-case-banner-bandit.json
@@ -5,8 +5,8 @@
       {
         "subjectKey": "alice",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 25}, 
-            "categorical_attributes": {"country": "USA", "gender_identity": "female"}
+            "numericAttributes": {"age": 25},
+            "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
         },
         "actions": [
             {
@@ -31,8 +31,8 @@
       {
         "subjectKey": "bob",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 30, "account_age": 10}, 
-            "categorical_attributes": {"country": "UK", "gender_identity": "male"}
+            "numericAttributes": {"age": 30, "account_age": 10},
+            "categoricalAttributes": {"country": "UK", "gender_identity": "male"}
         },
         "actions": [
             {
@@ -57,8 +57,8 @@
       {
         "subjectKey": "charlie",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 50, "account_age": 2}, 
-            "categorical_attributes": {"country": "UK", "gender_identity": "unknown"}
+            "numericAttributes": {"age": 50, "account_age": 2},
+            "categoricalAttributes": {"country": "UK", "gender_identity": "unknown"}
         },
         "actions": [
             {
@@ -83,8 +83,8 @@
       {
         "subjectKey": "debra",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 28, "account_age": 30}, 
-            "categorical_attributes": {"country": "Canada", "gender_identity": "unknown"}
+            "numericAttributes": {"age": 28, "account_age": 30},
+            "categoricalAttributes": {"country": "Canada", "gender_identity": "unknown"}
         },
         "actions": [
             {
@@ -109,8 +109,8 @@
       {
         "subjectKey": "erica",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 28, "account_age": 30}, 
-            "categorical_attributes": {"country": "USA", "gender_identity": "female"}
+            "numericAttributes": {"age": 28, "account_age": 30},
+            "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
         },
         "actions": [
             {
@@ -145,8 +145,8 @@
       {
         "subjectKey": "frenkie",
         "subjectAttributes": {
-            "numeric_attributes": {"age": 31, "account_age": 4}, 
-            "categorical_attributes": {"country": "Netherlands", "gender_identity": "male"}
+            "numericAttributes": {"age": 31, "account_age": 4},
+            "categoricalAttributes": {"country": "Netherlands", "gender_identity": "male"}
         },
         "actions": [
             {
@@ -180,8 +180,8 @@
       {
         "subjectKey": "gerard",
         "subjectAttributes": {
-            "numeric_attributes": {"age": null}, 
-            "categorical_attributes": {"country": null, "gender_identity": null}
+            "numericAttributes": {"age": null},
+            "categoricalAttributes": {"country": null, "gender_identity": null}
         },
         "actions": [
             {

--- a/ufc/bandit-tests/test-case-non-bandit-flag.json
+++ b/ufc/bandit-tests/test-case-non-bandit-flag.json
@@ -4,7 +4,7 @@
     "subjects": [
       {
         "subjectKey": "alice",
-        "subjectAttributes": {"numeric_attributes": {"age": 25}, "categorical_attributes": {"country": "USA"}},
+        "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
         "actions": [],
         "assignment": {"variation": "control", "action": null}
       }

--- a/ufc/bandit-tests/test-case-non-bandit-integer-flag.json
+++ b/ufc/bandit-tests/test-case-non-bandit-integer-flag.json
@@ -4,7 +4,7 @@
     "subjects": [
       {
         "subjectKey": "alice",
-        "subjectAttributes": {"numeric_attributes": {"age": 25}, "categorical_attributes": {"country": "USA"}},
+        "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
         "actions": [],
         "assignment": {"variation": "default", "action": null}
       }


### PR DESCRIPTION
Adds test cases that cover:
* Number passed as a subject categorical attribute
* Non-number passed as a subject numeric attribute
* Number passed as an action categorical attribute
* Non-number passed as an action numeric attribute

The tests are designed with assignments close to the boundary of the action weights so that if the numbers are not treated as categorical attributes and weighted appropriately, the tests will fail.

