### PR TITLE
FF-2526 include environment and allocation.name in UFC response

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -1,5 +1,6 @@
 {
     "createdAt": "2024-04-17T19:40:53.716Z",
+    "environment": "Test",
     "flags": {
       "non_bandit_flag": {
         "key": "non_bandit_flag",

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -13,6 +13,7 @@
         "allocations": [
             {
                 "key": "control-allocation",
+                "name": "Allocation for control-allocation",
                 "splits": [
                     {
                         "variationKey": "control",
@@ -34,6 +35,7 @@
         "allocations": [
             {
                 "key": "control-allocation",
+                "name": "Allocation for control-allocation",
                 "splits": [
                     {
                         "variationKey": "control",
@@ -55,6 +57,7 @@
         "allocations": [
             {
                 "key": "analysis",
+                "name": "Allocation for analysis",
                 "splits": [
                     {
                         "variationKey": "control",
@@ -87,6 +90,7 @@
             },
             {
                 "key": "training",
+                "name": "Allocation for training",
                 "splits": [
                     {
                         "variationKey": "banner_bandit",
@@ -114,6 +118,7 @@
         "allocations": [
             {
                 "key": "training",
+                "name": "Allocation for training",
                 "rules": [
                     {
                       "conditions": [
@@ -137,6 +142,7 @@
             },
             {
                 "key": "default",
+                "name": "Allocation for default",
                 "rules": [],
                 "splits": [
                     {

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -1,6 +1,8 @@
 {
     "createdAt": "2024-04-17T19:40:53.716Z",
-    "environment": "Test",
+    "environment": {
+      "name": "Test"
+    },
     "flags": {
       "non_bandit_flag": {
         "key": "non_bandit_flag",

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -1,6 +1,8 @@
 {
   "updatedAt": "2023-09-13T04:52:06.462Z",
-  "environment": "Test",
+  "environment": {
+    "name": "Test"
+  },
   "bandits": {
     "banner_bandit": {
       "banditKey": "banner_bandit",

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -1,5 +1,6 @@
 {
   "updatedAt": "2023-09-13T04:52:06.462Z",
+  "environment": "Test",
   "bandits": {
     "banner_bandit": {
       "banditKey": "banner_bandit",

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,5 +1,6 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
+  "environment": "Test",
   "flags": {
     "73fcc84c69e49e31fe16a29b2b1f803b": {
       "key": "73fcc84c69e49e31fe16a29b2b1f803b",

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -53,6 +53,7 @@
       "allocations": [
         {
           "key": "cm9sbG91dA==",
+          "name": "QWxsb2NhdGlvbiBmb3Igcm9sbG91dA==",
           "doLog": true,
           "splits": [
             {
@@ -81,6 +82,7 @@
       "allocations": [
         {
           "key": "dmFsaWQ=",
+          "name": "QWxsb2NhdGlvbiBmb3IgdmFsaWQ=",
           "doLog": true,
           "rules": [
             {
@@ -104,6 +106,7 @@
         },
         {
           "key": "aW52YWxpZA==",
+          "name": "QWxsb2NhdGlvbiBmb3IgaW52YWxpZA==",
           "doLog": true,
           "rules": [],
           "splits": [
@@ -133,6 +136,7 @@
       "allocations": [
         {
           "key": "cGFydGlhbC1leGFtcGxl",
+          "name": "QWxsb2NhdGlvbiBmb3IgcGFydGlhbC1leGFtcGxl",
           "doLog": true,
           "rules": [
             {
@@ -154,6 +158,7 @@
         },
         {
           "key": "dGVzdA==",
+          "name": "QWxsb2NhdGlvbiBmb3IgdGVzdA==",
           "doLog": true,
           "rules": [
             {
@@ -197,6 +202,7 @@
       "allocations": [
         {
           "key": "MS1mb3ItMQ==",
+          "name": "QWxsb2NhdGlvbiBmb3IgMS1mb3ItMQ==",
           "doLog": true,
           "rules": [
             {
@@ -220,6 +226,7 @@
         },
         {
           "key": "Mi1mb3ItMTIzNDU2Nzg5",
+          "name": "QWxsb2NhdGlvbiBmb3IgMi1mb3ItMTIzNDU2Nzg5",
           "doLog": true,
           "rules": [
             {
@@ -243,6 +250,7 @@
         },
         {
           "key": "My1mb3Itbm90LTI=",
+          "name": "QWxsb2NhdGlvbiBmb3IgMy1mb3Itbm90LTI=",
           "doLog": true,
           "rules": [
             {
@@ -296,6 +304,7 @@
       "allocations": [
         {
           "key": "MS1mb3Itb25lLW9m",
+          "name": "QWxsb2NhdGlvbiBmb3IgMS1mb3Itb25lLW9m",
           "doLog": true,
           "rules": [
             {
@@ -319,6 +328,7 @@
         },
         {
           "key": "Mi1mb3ItbWF0Y2hlcw==",
+          "name": "QWxsb2NhdGlvbiBmb3IgMi1mb3ItbWF0Y2hlcw==",
           "doLog": true,
           "rules": [
             {
@@ -340,6 +350,7 @@
         },
         {
           "key": "My1mb3Itbm90LW9uZS1vZg==",
+          "name": "QWxsb2NhdGlvbiBmb3IgMy1mb3Itbm90LW9uZS1vZg==",
           "doLog": true,
           "rules": [
             {
@@ -363,6 +374,7 @@
         },
         {
           "key": "NC1mb3Itbm90LW1hdGNoZXM=",
+          "name": "QWxsb2NhdGlvbiBmb3IgNC1mb3Itbm90LW1hdGNoZXM=",
           "doLog": true,
           "rules": [
             {
@@ -384,6 +396,7 @@
         },
         {
           "key": "NS1mb3ItbWF0Y2hlcy1udWxs",
+          "name": "QWxsb2NhdGlvbiBmb3IgNS1mb3ItbWF0Y2hlcy1udWxs",
           "doLog": true,
           "rules": [
             {
@@ -425,6 +438,7 @@
       "allocations": [
         {
           "key": "b24tZm9yLU5B",
+          "name": "QWxsb2NhdGlvbiBmb3Igb24tZm9yLU5B",
           "doLog": true,
           "rules": [
             {
@@ -460,6 +474,7 @@
         },
         {
           "key": "b24tZm9yLWFnZS01MCs=",
+          "name": "QWxsb2NhdGlvbiBmb3Igb24tZm9yLWFnZS01MCs=",
           "doLog": true,
           "rules": [
             {
@@ -491,6 +506,7 @@
         },
         {
           "key": "b2ZmLWZvci1hbGw=",
+          "name": "QWxsb2NhdGlvbiBmb3Igb2ZmLWZvci1hbGw=",
           "doLog": true,
           "rules": [],
           "splits": [
@@ -524,6 +540,7 @@
       "allocations": [
         {
           "key": "b2xkLXZlcnNpb25z",
+          "name": "QWxsb2NhdGlvbiBmb3Igb2xkLXZlcnNpb25z",
           "doLog": true,
           "rules": [
             {
@@ -545,6 +562,7 @@
         },
         {
           "key": "Y3VycmVudC12ZXJzaW9ucw==",
+          "name": "QWxsb2NhdGlvbiBmb3IgY3VycmVudC12ZXJzaW9ucw==",
           "doLog": true,
           "rules": [
             {
@@ -571,6 +589,7 @@
         },
         {
           "key": "bmV3LXZlcnNpb25z",
+          "name": "QWxsb2NhdGlvbiBmb3IgbmV3LXZlcnNpb25z",
           "doLog": true,
           "rules": [
             {
@@ -614,6 +633,7 @@
       "allocations": [
         {
           "key": "c21hbGwtc2l6ZQ==",
+          "name": "QWxsb2NhdGlvbiBmb3Igc21hbGwtc2l6ZQ==",
           "doLog": true,
           "rules": [
             {
@@ -635,6 +655,7 @@
         },
         {
           "key": "bWVkdW0tc2l6ZQ==",
+          "name": "QWxsb2NhdGlvbiBmb3IgbWVkdW0tc2l6ZQ==",
           "doLog": true,
           "rules": [
             {
@@ -661,6 +682,7 @@
         },
         {
           "key": "bGFyZ2Utc2l6ZQ==",
+          "name": "QWxsb2NhdGlvbiBmb3IgbGFyZ2Utc2l6ZQ==",
           "doLog": true,
           "rules": [
             {
@@ -704,6 +726,7 @@
       "allocations": [
         {
           "key": "b2xkLXZlcnNpb25z",
+          "name": "QWxsb2NhdGlvbiBmb3Igb2xkLXZlcnNpb25z",
           "doLog": true,
           "endAt": "MjAwMi0xMC0zMVQwOTowMDowMC41OTRa",
           "splits": [
@@ -715,6 +738,7 @@
         },
         {
           "key": "ZnV0dXJlLXZlcnNpb25z",
+          "name": "QWxsb2NhdGlvbiBmb3IgZnV0dXJlLXZlcnNpb25z",
           "doLog": true,
           "startAt": "MjA1Mi0xMC0zMVQwOTowMDowMC41OTRa",
           "splits": [
@@ -726,6 +750,7 @@
         },
         {
           "key": "Y3VycmVudC12ZXJzaW9ucw==",
+          "name": "QWxsb2NhdGlvbiBmb3IgY3VycmVudC12ZXJzaW9ucw==",
           "doLog": true,
           "startAt": "MjAyMi0xMC0zMVQwOTowMDowMC41OTRa",
           "endAt": "MjA1MC0xMC0zMVQwOTowMDowMC41OTRa",
@@ -756,6 +781,7 @@
       "allocations": [
         {
           "key": "bnVsbC1vcGVyYXRvcg==",
+          "name": "QWxsb2NhdGlvbiBmb3IgbnVsbC1vcGVyYXRvcg==",
           "doLog": true,
           "rules": [
             {
@@ -786,6 +812,7 @@
         },
         {
           "key": "bm90LW51bGwtb3BlcmF0b3I=",
+          "name": "QWxsb2NhdGlvbiBmb3Igbm90LW51bGwtb3BlcmF0b3I=",
           "doLog": true,
           "rules": [
             {
@@ -841,6 +868,7 @@
       "allocations": [
         {
           "key": "aWQgcnVsZQ==",
+          "name": "QWxsb2NhdGlvbiBmb3IgaWQgcnVsZQ==",
           "doLog": false,
           "rules": [
             {
@@ -862,6 +890,7 @@
         },
         {
           "key": "aW50ZXJuYWwgdXNlcnM=",
+          "name": "QWxsb2NhdGlvbiBmb3IgaW50ZXJuYWwgdXNlcnM=",
           "doLog": false,
           "rules": [
             {
@@ -883,6 +912,7 @@
         },
         {
           "key": "ZXhwZXJpbWVudA==",
+          "name": "QWxsb2NhdGlvbiBmb3IgZXhwZXJpbWVudA==",
           "doLog": true,
           "rules": [
             {
@@ -973,6 +1003,7 @@
         },
         {
           "key": "cm9sbG91dA==",
+          "name": "QWxsb2NhdGlvbiBmb3Igcm9sbG91dA==",
           "doLog": true,
           "rules": [
             {
@@ -1034,6 +1065,7 @@
       "allocations": [
         {
           "key": "dGFyZ2V0ZWQgYWxsb2NhdGlvbg==",
+          "name": "QWxsb2NhdGlvbiBmb3IgdGFyZ2V0ZWQgYWxsb2NhdGlvbg==",
           "doLog": true,
           "rules": [
             {
@@ -1078,6 +1110,7 @@
         },
         {
           "key": "NTAvNTAgc3BsaXQ=",
+          "name": "QWxsb2NhdGlvbiBmb3IgNTAvNTAgc3BsaXQ=",
           "doLog": true,
           "rules": [],
           "splits": [
@@ -1131,6 +1164,7 @@
       "allocations": [
         {
           "key": "NTAvNTAgc3BsaXQ=",
+          "name": "QWxsb2NhdGlvbiBmb3IgNTAvNTAgc3BsaXQ=",
           "doLog": true,
           "rules": [],
           "splits": [

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,6 +1,8 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
-  "environment": "Test",
+  "environment": {
+    "name": "Test"
+  },
   "flags": {
     "73fcc84c69e49e31fe16a29b2b1f803b": {
       "key": "73fcc84c69e49e31fe16a29b2b1f803b",

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -52,6 +52,7 @@
       "allocations": [
         {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "splits": [
             {
               "variationKey": "pi",
@@ -80,6 +81,7 @@
       "allocations": [
         {
           "key": "valid",
+          "name": "Allocation for valid",
           "rules": [
             {
               "conditions": [
@@ -103,6 +105,7 @@
         },
         {
           "key": "invalid",
+          "name": "Allocation for invalid",
           "rules": [],
           "splits": [
             {
@@ -132,6 +135,7 @@
       "allocations": [
         {
           "key": "partial-example",
+          "name": "Allocation for partial-example",
           "rules": [
             {
               "conditions": [
@@ -153,6 +157,7 @@
         },
         {
           "key": "test",
+          "name": "Allocation for test",
           "rules": [
             {
               "conditions": [
@@ -196,6 +201,7 @@
       "allocations": [
         {
           "key": "1-for-1",
+          "name": "Allocation for 1-for-1",
           "rules": [
             {
               "conditions": [
@@ -219,6 +225,7 @@
         },
         {
           "key": "2-for-123456789",
+          "name": "Allocation for 2-for-123456789",
           "rules": [
             {
               "conditions": [
@@ -242,6 +249,7 @@
         },
         {
           "key": "3-for-not-2",
+          "name": "Allocation for 3-for-not-2",
           "rules": [
             {
               "conditions": [
@@ -295,6 +303,7 @@
       "allocations": [
         {
           "key": "1-for-one-of",
+          "name": "Allocation for 1-for-one-of",
           "rules": [
             {
               "conditions": [
@@ -318,6 +327,7 @@
         },
         {
           "key": "2-for-matches",
+          "name": "Allocation for 2-for-matches",
           "rules": [
             {
               "conditions": [
@@ -339,6 +349,7 @@
         },
         {
           "key": "3-for-not-one-of",
+          "name": "Allocation for 3-for-not-one-of",
           "rules": [
             {
               "conditions": [
@@ -362,6 +373,7 @@
         },
         {
           "key": "4-for-not-matches",
+          "name": "Allocation for 4-for-not-matches",
           "rules": [
             {
               "conditions": [
@@ -383,6 +395,7 @@
         },
         {
           "key": "5-for-matches-null",
+          "name": "Allocation for 5-for-matches-null",
           "rules": [
             {
               "conditions": [
@@ -424,6 +437,7 @@
       "allocations": [
         {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "rules": [
             {
               "conditions": [
@@ -459,6 +473,7 @@
         },
         {
           "key": "on-for-age-50+",
+          "name": "Allocation for on-for-age-50+",
           "rules": [
             {
               "conditions": [
@@ -490,6 +505,7 @@
         },
         {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "rules": [],
           "splits": [
             {
@@ -523,6 +539,7 @@
       "allocations": [
         {
           "key": "old-versions",
+          "name": "Allocation for old-versions",
           "rules": [
             {
               "conditions": [
@@ -544,6 +561,7 @@
         },
         {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "rules": [
             {
               "conditions": [
@@ -570,6 +588,7 @@
         },
         {
           "key": "new-versions",
+          "name": "Allocation for new-versions",
           "rules": [
             {
               "conditions": [
@@ -613,6 +632,7 @@
       "allocations": [
         {
           "key": "small-size",
+          "name": "Allocation for small-size",
           "rules": [
             {
               "conditions": [
@@ -634,6 +654,7 @@
         },
         {
           "key": "medum-size",
+          "name": "Allocation for medum-size",
           "rules": [
             {
               "conditions": [
@@ -660,6 +681,7 @@
         },
         {
           "key": "large-size",
+          "name": "Allocation for large-size",
           "rules": [
             {
               "conditions": [
@@ -703,6 +725,7 @@
       "allocations": [
         {
           "key": "old-versions",
+          "name": "Allocation for old-versions",
           "splits": [
             {
               "variationKey": "old",
@@ -714,6 +737,7 @@
         },
         {
           "key": "future-versions",
+          "name": "Allocation for future-versions",
           "splits": [
             {
               "variationKey": "future",
@@ -725,6 +749,7 @@
         },
         {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "splits": [
             {
               "variationKey": "current",
@@ -755,6 +780,7 @@
       "allocations": [
         {
           "key": "null-operator",
+          "name": "Allocation for null-operator",
           "rules": [
             {
               "conditions": [
@@ -785,6 +811,7 @@
         },
         {
           "key": "not-null-operator",
+          "name": "Allocation for not-null-operator",
           "rules": [
             {
               "conditions": [
@@ -840,6 +867,7 @@
       "allocations": [
         {
           "key": "id rule",
+          "name": "Allocation for id rule",
           "rules": [
             {
               "conditions": [
@@ -861,6 +889,7 @@
         },
         {
           "key": "internal users",
+          "name": "Allocation for internal users",
           "rules": [
             {
               "conditions": [
@@ -882,6 +911,7 @@
         },
         {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "rules": [
             {
               "conditions": [
@@ -972,6 +1002,7 @@
         },
         {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "rules": [
             {
               "conditions": [
@@ -1033,6 +1064,7 @@
       "allocations": [
         {
           "key": "targeted allocation",
+          "name": "Allocation for targeted allocation",
           "rules": [
             {
               "conditions": [
@@ -1077,6 +1109,7 @@
         },
         {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "rules": [],
           "splits": [
             {
@@ -1130,6 +1163,7 @@
       "allocations": [
         {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "rules": [],
           "splits": [
             {

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1,6 +1,8 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
-  "environment": "Test",
+  "environment": {
+    "name": "Test"
+  },
   "flags": {
     "empty_flag": {
       "key": "empty_flag",

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1,5 +1,6 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
+  "environment": "Test",
   "flags": {
     "empty_flag": {
       "key": "empty_flag",

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -11,7 +11,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-one-of\".",
         "variationKey": "1",
@@ -70,7 +72,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -120,7 +124,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -170,7 +176,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-matches\".",
         "variationKey": "2",
@@ -228,7 +236,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -278,7 +288,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -328,7 +340,9 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -386,7 +400,9 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -444,7 +460,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -504,7 +522,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -554,7 +574,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -614,7 +636,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -674,7 +698,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -724,7 +750,9 @@
       "assignment": 5,
       "assignmentDetails": {
         "value": 5,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"5-for-matches-null\".",
         "variationKey": "5",
@@ -783,7 +811,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -831,7 +861,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -11,6 +11,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-one-of\".",
         "variationKey": "1",
@@ -28,6 +29,7 @@
         },
         "matchedAllocation": {
           "key": "1-for-one-of",
+          "name": "Allocation for 1-for-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -35,21 +37,25 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -64,6 +70,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -73,26 +80,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -108,6 +120,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -117,26 +130,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -152,6 +170,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-matches\".",
         "variationKey": "2",
@@ -167,12 +186,14 @@
         },
         "matchedAllocation": {
           "key": "2-for-matches",
+          "name": "Allocation for 2-for-matches",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -180,16 +201,19 @@
         "unevaluatedAllocations": [
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -204,6 +228,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -213,26 +238,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -248,6 +278,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -257,26 +288,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -292,6 +328,7 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -307,22 +344,26 @@
         },
         "matchedAllocation": {
           "key": "4-for-not-matches",
+          "name": "Allocation for 4-for-not-matches",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -330,6 +371,7 @@
         "unevaluatedAllocations": [
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -344,6 +386,7 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -359,22 +402,26 @@
         },
         "matchedAllocation": {
           "key": "4-for-not-matches",
+          "name": "Allocation for 4-for-not-matches",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -382,6 +429,7 @@
         "unevaluatedAllocations": [
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -396,6 +444,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -413,17 +462,20 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-one-of",
+          "name": "Allocation for 3-for-not-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -431,11 +483,13 @@
         "unevaluatedAllocations": [
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -450,6 +504,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -459,26 +514,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -494,6 +554,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -511,17 +572,20 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-one-of",
+          "name": "Allocation for 3-for-not-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -529,11 +593,13 @@
         "unevaluatedAllocations": [
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -548,6 +614,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -565,17 +632,20 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-one-of",
+          "name": "Allocation for 3-for-not-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -583,11 +653,13 @@
         "unevaluatedAllocations": [
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -602,6 +674,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -611,26 +684,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -646,6 +724,7 @@
       "assignment": 5,
       "assignmentDetails": {
         "value": 5,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"5-for-matches-null\".",
         "variationKey": "5",
@@ -663,27 +742,32 @@
         },
         "matchedAllocation": {
           "key": "5-for-matches-null",
+          "name": "Allocation for 5-for-matches-null",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 5
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -699,6 +783,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -708,26 +793,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -741,6 +831,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -750,26 +841,31 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
+            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
+            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
+            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
+            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
+            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -12,6 +12,7 @@
       "assignment": "small",
       "assignmentDetails": {
         "value": "small",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"small-size\".",
         "variationKey": "small",
@@ -27,6 +28,7 @@
         },
         "matchedAllocation": {
           "key": "small-size",
+          "name": "Allocation for small-size",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -34,11 +36,13 @@
         "unevaluatedAllocations": [
           {
             "key": "medum-size",
+            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "large-size",
+            "name": "Allocation for large-size",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -54,6 +58,7 @@
       "assignment": "medium",
       "assignmentDetails": {
         "value": "medium",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"medum-size\".",
         "variationKey": "medium",
@@ -74,12 +79,14 @@
         },
         "matchedAllocation": {
           "key": "medum-size",
+          "name": "Allocation for medum-size",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "small-size",
+            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -87,6 +94,7 @@
         "unevaluatedAllocations": [
           {
             "key": "large-size",
+            "name": "Allocation for large-size",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -101,6 +109,7 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -110,16 +119,19 @@
         "unmatchedAllocations": [
           {
             "key": "small-size",
+            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "medum-size",
+            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "large-size",
+            "name": "Allocation for large-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -135,6 +147,7 @@
       "assignment": "large",
       "assignmentDetails": {
         "value": "large",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"large-size\".",
         "variationKey": "large",
@@ -150,17 +163,20 @@
         },
         "matchedAllocation": {
           "key": "large-size",
+          "name": "Allocation for large-size",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "small-size",
+            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "medum-size",
+            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -176,6 +192,7 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -185,16 +202,19 @@
         "unmatchedAllocations": [
           {
             "key": "small-size",
+            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "medum-size",
+            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "large-size",
+            "name": "Allocation for large-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -12,7 +12,9 @@
       "assignment": "small",
       "assignmentDetails": {
         "value": "small",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"small-size\".",
         "variationKey": "small",
@@ -58,7 +60,9 @@
       "assignment": "medium",
       "assignmentDetails": {
         "value": "medium",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"medum-size\".",
         "variationKey": "medium",
@@ -109,7 +113,9 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -147,7 +153,9 @@
       "assignment": "large",
       "assignmentDetails": {
         "value": "large",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"large-size\".",
         "variationKey": "large",
@@ -192,7 +200,9 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-disabled-flag.json
+++ b/ufc/tests/test-case-disabled-flag.json
@@ -12,7 +12,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -32,7 +34,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -51,7 +55,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,

--- a/ufc/tests/test-case-disabled-flag.json
+++ b/ufc/tests/test-case-disabled-flag.json
@@ -12,6 +12,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -31,6 +32,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -49,6 +51,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,

--- a/ufc/tests/test-case-empty-flag.json
+++ b/ufc/tests/test-case-empty-flag.json
@@ -12,7 +12,9 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -32,7 +34,9 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -51,7 +55,9 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-empty-flag.json
+++ b/ufc/tests/test-case-empty-flag.json
@@ -12,6 +12,7 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -31,6 +32,7 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -49,6 +51,7 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -12,7 +12,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -56,7 +58,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -99,7 +103,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -132,7 +138,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -173,7 +181,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -202,7 +212,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "2 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -231,7 +243,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "3 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -260,7 +274,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -289,7 +305,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -318,7 +336,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -347,7 +367,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "7 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -376,7 +398,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "8 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -405,7 +429,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -434,7 +460,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -463,7 +491,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -492,7 +522,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "12 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -521,7 +553,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "13 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -550,7 +584,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -579,7 +615,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -608,7 +646,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -637,7 +677,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -666,7 +708,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -695,7 +739,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -12,6 +12,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -31,6 +32,7 @@
         },
         "matchedAllocation": {
           "key": "targeted allocation",
+          "name": "Allocation for targeted allocation",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -38,6 +40,7 @@
         "unevaluatedAllocations": [
           {
             "key": "50/50 split",
+            "name": "Allocation for 50/50 split",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -53,6 +56,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -72,6 +76,7 @@
         },
         "matchedAllocation": {
           "key": "targeted allocation",
+          "name": "Allocation for targeted allocation",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -79,6 +84,7 @@
         "unevaluatedAllocations": [
           {
             "key": "50/50 split",
+            "name": "Allocation for 50/50 split",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -93,6 +99,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -100,12 +107,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -123,6 +132,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -142,6 +152,7 @@
         },
         "matchedAllocation": {
           "key": "targeted allocation",
+          "name": "Allocation for targeted allocation",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -149,6 +160,7 @@
         "unevaluatedAllocations": [
           {
             "key": "50/50 split",
+            "name": "Allocation for 50/50 split",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -161,6 +173,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -168,12 +181,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -187,6 +202,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "2 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -194,12 +210,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -213,6 +231,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "3 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -220,12 +239,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -239,6 +260,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -246,12 +268,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -265,6 +289,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -272,12 +297,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -291,6 +318,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -298,12 +326,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -317,6 +347,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "7 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -324,12 +355,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -343,6 +376,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "8 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -350,12 +384,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -369,6 +405,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -376,12 +413,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -395,6 +434,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -402,12 +442,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -421,6 +463,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -428,12 +471,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -447,6 +492,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "12 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -454,12 +500,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -473,6 +521,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "13 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -480,12 +529,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -499,6 +550,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -506,12 +558,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -525,6 +579,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -532,12 +587,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -551,6 +608,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -558,12 +616,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -577,6 +637,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -584,12 +645,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -603,6 +666,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -610,12 +674,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -629,6 +695,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -636,12 +703,14 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
+            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -12,7 +12,9 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,
@@ -45,7 +47,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"valid\".",
         "variationKey": "one",
@@ -86,7 +90,9 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -12,6 +12,7 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
+        "environment": "Test",
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,
@@ -22,11 +23,13 @@
         "unevaluatedAllocations": [
           {
             "key": "valid",
+            "name": "Allocation for valid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 1
           },
           {
             "key": "invalid",
+            "name": "Allocation for invalid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -42,6 +45,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"valid\".",
         "variationKey": "one",
@@ -59,6 +63,7 @@
         },
         "matchedAllocation": {
           "key": "valid",
+          "name": "Allocation for valid",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -66,6 +71,7 @@
         "unevaluatedAllocations": [
           {
             "key": "invalid",
+            "name": "Allocation for invalid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -80,6 +86,7 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
+        "environment": "Test",
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,
@@ -90,11 +97,13 @@
         "unevaluatedAllocations": [
           {
             "key": "valid",
+            "name": "Allocation for valid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 1
           },
           {
             "key": "invalid",
+            "name": "Allocation for invalid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-kill-switch-flag.json
+++ b/ufc/tests/test-case-kill-switch-flag.json
@@ -12,7 +12,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -62,7 +64,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -112,7 +116,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "barbara belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -149,7 +155,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -188,7 +196,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -235,7 +245,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -272,7 +284,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -322,7 +336,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -368,7 +384,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -405,7 +423,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -442,7 +462,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -480,7 +502,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -530,7 +554,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -576,7 +602,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -611,7 +639,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -646,7 +676,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -683,7 +715,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -732,7 +766,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -779,7 +815,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -816,7 +854,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -853,7 +893,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -890,7 +932,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -927,7 +971,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -964,7 +1010,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",

--- a/ufc/tests/test-case-kill-switch-flag.json
+++ b/ufc/tests/test-case-kill-switch-flag.json
@@ -12,6 +12,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -31,6 +32,7 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -38,11 +40,13 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -58,6 +62,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -77,6 +82,7 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -84,11 +90,13 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -104,6 +112,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "barbara belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -111,17 +120,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -137,6 +149,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -144,17 +157,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -172,6 +188,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -191,6 +208,7 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -198,11 +216,13 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -215,6 +235,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -222,17 +243,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -248,6 +272,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -267,6 +292,7 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -274,11 +300,13 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -294,6 +322,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -309,12 +338,14 @@
         },
         "matchedAllocation": {
           "key": "on-for-age-50+",
+          "name": "Allocation for on-for-age-50+",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -322,6 +353,7 @@
         "unevaluatedAllocations": [
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -336,6 +368,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -343,17 +376,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -369,6 +405,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -376,17 +413,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -402,6 +442,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -409,17 +450,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -436,6 +480,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -455,6 +500,7 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -462,11 +508,13 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -482,6 +530,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -497,12 +546,14 @@
         },
         "matchedAllocation": {
           "key": "on-for-age-50+",
+          "name": "Allocation for on-for-age-50+",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -510,6 +561,7 @@
         "unevaluatedAllocations": [
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -524,6 +576,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -531,17 +584,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -555,6 +611,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -562,17 +619,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -586,6 +646,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -593,17 +654,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -619,6 +683,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -638,6 +703,7 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -645,11 +711,13 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -664,6 +732,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -683,6 +752,7 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
+          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -690,11 +760,13 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
+            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -707,6 +779,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -714,17 +787,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -740,6 +816,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -747,17 +824,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -773,6 +853,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -780,17 +861,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -806,6 +890,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -813,17 +898,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -839,6 +927,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -846,17 +935,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -872,6 +964,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -879,17 +972,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
+          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
+            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
+            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-new-user-onboarding-flag.json
+++ b/ufc/tests/test-case-new-user-onboarding-flag.json
@@ -12,7 +12,9 @@
       "assignment": "green",
       "assignmentDetails": {
         "value": "green",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"internal users\".",
         "variationKey": "green",
@@ -65,7 +67,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -109,7 +113,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -155,7 +161,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -212,7 +220,9 @@
       "assignment": "purple",
       "assignmentDetails": {
         "value": "purple",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"id rule\".",
         "variationKey": "purple",
@@ -266,7 +276,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -323,7 +335,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -365,7 +379,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -409,7 +425,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -465,7 +483,9 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 3 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -521,7 +541,9 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 4 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -577,7 +599,9 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 5 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -633,7 +657,9 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 6 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -689,7 +715,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -744,7 +772,9 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 8 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -800,7 +830,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -842,7 +874,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -884,7 +918,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -928,7 +964,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -983,7 +1021,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -1036,7 +1076,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1080,7 +1122,9 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 15 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -1136,7 +1180,9 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 16 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1192,7 +1238,9 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 17 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1248,7 +1296,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1292,7 +1342,9 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 19 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",

--- a/ufc/tests/test-case-new-user-onboarding-flag.json
+++ b/ufc/tests/test-case-new-user-onboarding-flag.json
@@ -12,6 +12,7 @@
       "assignment": "green",
       "assignmentDetails": {
         "value": "green",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"internal users\".",
         "variationKey": "green",
@@ -27,12 +28,14 @@
         },
         "matchedAllocation": {
           "key": "internal users",
+          "name": "Allocation for internal users",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -40,11 +43,13 @@
         "unevaluatedAllocations": [
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -60,6 +65,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -69,21 +75,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
             "orderPosition": 4
           }
@@ -99,6 +109,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -108,21 +119,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -140,6 +155,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -159,22 +175,26 @@
         },
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -192,6 +212,7 @@
       "assignment": "purple",
       "assignmentDetails": {
         "value": "purple",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"id rule\".",
         "variationKey": "purple",
@@ -207,6 +228,7 @@
         },
         "matchedAllocation": {
           "key": "id rule",
+          "name": "Allocation for id rule",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -214,16 +236,19 @@
         "unevaluatedAllocations": [
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -241,6 +266,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -260,22 +286,26 @@
         },
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -293,6 +323,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -302,21 +333,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
             "orderPosition": 4
           }
@@ -330,6 +365,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -339,21 +375,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -369,6 +409,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -388,22 +429,26 @@
         },
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -420,6 +465,7 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 3 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -439,17 +485,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -457,6 +506,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -471,6 +521,7 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 4 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -490,17 +541,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -508,6 +562,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -522,6 +577,7 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 5 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -541,17 +597,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -559,6 +618,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -573,6 +633,7 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 6 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -592,17 +653,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -610,6 +674,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -624,6 +689,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -643,22 +709,26 @@
         },
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -674,6 +744,7 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 8 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -693,17 +764,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -711,6 +785,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -725,6 +800,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -734,21 +810,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -762,6 +842,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -771,21 +852,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -799,6 +884,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -808,21 +894,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -838,6 +928,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -857,22 +948,26 @@
         },
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -888,6 +983,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -907,22 +1003,26 @@
         },
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -936,6 +1036,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -945,21 +1046,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -975,6 +1080,7 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 15 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -994,17 +1100,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1012,6 +1121,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -1026,6 +1136,7 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 16 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1045,17 +1156,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1063,6 +1177,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -1077,6 +1192,7 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 17 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1096,17 +1212,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1114,6 +1233,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -1128,6 +1248,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1137,21 +1258,25 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
+            "name": "Allocation for experiment",
             "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
             "orderPosition": 3
           },
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -1167,6 +1292,7 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 19 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -1186,17 +1312,20 @@
         },
         "matchedAllocation": {
           "key": "experiment",
+          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
+            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
+            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1204,6 +1333,7 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
+            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -12,7 +12,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -52,7 +54,9 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -91,7 +95,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -130,7 +136,9 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -169,7 +177,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -12,6 +12,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -27,6 +28,7 @@
         },
         "matchedAllocation": {
           "key": "null-operator",
+          "name": "Allocation for null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -34,6 +36,7 @@
         "unevaluatedAllocations": [
           {
             "key": "not-null-operator",
+            "name": "Allocation for not-null-operator",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -49,6 +52,7 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -64,12 +68,14 @@
         },
         "matchedAllocation": {
           "key": "not-null-operator",
+          "name": "Allocation for not-null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "null-operator",
+            "name": "Allocation for null-operator",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -85,6 +91,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -100,6 +107,7 @@
         },
         "matchedAllocation": {
           "key": "null-operator",
+          "name": "Allocation for null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -107,6 +115,7 @@
         "unevaluatedAllocations": [
           {
             "key": "not-null-operator",
+            "name": "Allocation for not-null-operator",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -121,6 +130,7 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -136,12 +146,14 @@
         },
         "matchedAllocation": {
           "key": "not-null-operator",
+          "name": "Allocation for not-null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "null-operator",
+            "name": "Allocation for null-operator",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -157,6 +169,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -172,6 +185,7 @@
         },
         "matchedAllocation": {
           "key": "null-operator",
+          "name": "Allocation for null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -179,6 +193,7 @@
         "unevaluatedAllocations": [
           {
             "key": "not-null-operator",
+            "name": "Allocation for not-null-operator",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-numeric-flag.json
+++ b/ufc/tests/test-case-numeric-flag.json
@@ -12,7 +12,9 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -37,7 +39,9 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -61,7 +65,9 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",

--- a/ufc/tests/test-case-numeric-flag.json
+++ b/ufc/tests/test-case-numeric-flag.json
@@ -12,6 +12,7 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -19,6 +20,7 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -35,6 +37,7 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -42,6 +45,7 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -57,6 +61,7 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -64,6 +69,7 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "rollout",
+          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },

--- a/ufc/tests/test-case-numeric-one-of.json
+++ b/ufc/tests/test-case-numeric-one-of.json
@@ -11,7 +11,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -58,7 +60,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -96,7 +100,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -143,7 +149,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -190,7 +198,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -237,7 +247,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -284,7 +296,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-123456789\".",
         "variationKey": "2",

--- a/ufc/tests/test-case-numeric-one-of.json
+++ b/ufc/tests/test-case-numeric-one-of.json
@@ -11,6 +11,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -28,6 +29,7 @@
         },
         "matchedAllocation": {
           "key": "1-for-1",
+          "name": "Allocation for 1-for-1",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -35,11 +37,13 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-123456789",
+            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
+            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -54,6 +58,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -63,16 +68,19 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
+            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-123456789",
+            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
+            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -88,6 +96,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -105,17 +114,20 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-2",
+          "name": "Allocation for 3-for-not-2",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
+            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-123456789",
+            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -131,6 +143,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -148,17 +161,20 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-2",
+          "name": "Allocation for 3-for-not-2",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
+            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-123456789",
+            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -174,6 +190,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -191,6 +208,7 @@
         },
         "matchedAllocation": {
           "key": "1-for-1",
+          "name": "Allocation for 1-for-1",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -198,11 +216,13 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-123456789",
+            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
+            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -217,6 +237,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -234,6 +255,7 @@
         },
         "matchedAllocation": {
           "key": "1-for-1",
+          "name": "Allocation for 1-for-1",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -241,11 +263,13 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-123456789",
+            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
+            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -260,6 +284,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-123456789\".",
         "variationKey": "2",
@@ -277,12 +302,14 @@
         },
         "matchedAllocation": {
           "key": "2-for-123456789",
+          "name": "Allocation for 2-for-123456789",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
+            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -290,6 +317,7 @@
         "unevaluatedAllocations": [
           {
             "key": "3-for-not-2",
+            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }

--- a/ufc/tests/test-case-regex-flag.json
+++ b/ufc/tests/test-case-regex-flag.json
@@ -12,6 +12,7 @@
       "assignment": "partial-example",
       "assignmentDetails": {
         "value": "partial-example",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"partial-example\".",
         "variationKey": "partial-example",
@@ -27,6 +28,7 @@
         },
         "matchedAllocation": {
           "key": "partial-example",
+          "name": "Allocation for partial-example",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -34,6 +36,7 @@
         "unevaluatedAllocations": [
           {
             "key": "test",
+            "name": "Allocation for test",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -49,6 +52,7 @@
       "assignment": "test",
       "assignmentDetails": {
         "value": "test",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"test\".",
         "variationKey": "test",
@@ -64,12 +68,14 @@
         },
         "matchedAllocation": {
           "key": "test",
+          "name": "Allocation for test",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "partial-example",
+            "name": "Allocation for partial-example",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -85,6 +91,7 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -94,11 +101,13 @@
         "unmatchedAllocations": [
           {
             "key": "partial-example",
+            "name": "Allocation for partial-example",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "test",
+            "name": "Allocation for test",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -115,6 +124,7 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -124,11 +134,13 @@
         "unmatchedAllocations": [
           {
             "key": "partial-example",
+            "name": "Allocation for partial-example",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "test",
+            "name": "Allocation for test",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-regex-flag.json
+++ b/ufc/tests/test-case-regex-flag.json
@@ -12,7 +12,9 @@
       "assignment": "partial-example",
       "assignmentDetails": {
         "value": "partial-example",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"partial-example\".",
         "variationKey": "partial-example",
@@ -52,7 +54,9 @@
       "assignment": "test",
       "assignmentDetails": {
         "value": "test",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"test\".",
         "variationKey": "test",
@@ -91,7 +95,9 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -124,7 +130,9 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -12,7 +12,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -64,7 +66,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"old-versions\".",
         "variationKey": "old",
@@ -109,7 +113,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -160,7 +166,9 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -198,7 +206,9 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"new-versions\".",
         "variationKey": "new",
@@ -243,7 +253,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -12,6 +12,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -32,12 +33,14 @@
         },
         "matchedAllocation": {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -45,6 +48,7 @@
         "unevaluatedAllocations": [
           {
             "key": "new-versions",
+            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -60,6 +64,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"old-versions\".",
         "variationKey": "old",
@@ -75,6 +80,7 @@
         },
         "matchedAllocation": {
           "key": "old-versions",
+          "name": "Allocation for old-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -82,11 +88,13 @@
         "unevaluatedAllocations": [
           {
             "key": "current-versions",
+            "name": "Allocation for current-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "new-versions",
+            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -101,6 +109,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -121,12 +130,14 @@
         },
         "matchedAllocation": {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -134,6 +145,7 @@
         "unevaluatedAllocations": [
           {
             "key": "new-versions",
+            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -148,6 +160,7 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
+        "environment": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -157,16 +170,19 @@
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "current-versions",
+            "name": "Allocation for current-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "new-versions",
+            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -182,6 +198,7 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"new-versions\".",
         "variationKey": "new",
@@ -197,17 +214,20 @@
         },
         "matchedAllocation": {
           "key": "new-versions",
+          "name": "Allocation for new-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "current-versions",
+            "name": "Allocation for current-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -223,6 +243,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -243,12 +264,14 @@
         },
         "matchedAllocation": {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -256,6 +279,7 @@
         "unevaluatedAllocations": [
           {
             "key": "new-versions",
+            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -12,6 +12,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -19,17 +20,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "AFTER_END_TIME",
             "orderPosition": 1
           },
           {
             "key": "future-versions",
+            "name": "Allocation for future-versions",
             "allocationEvaluationCode": "BEFORE_START_TIME",
             "orderPosition": 2
           }
@@ -46,6 +50,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -53,17 +58,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "AFTER_END_TIME",
             "orderPosition": 1
           },
           {
             "key": "future-versions",
+            "name": "Allocation for future-versions",
             "allocationEvaluationCode": "BEFORE_START_TIME",
             "orderPosition": 2
           }
@@ -79,6 +87,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environment": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -86,17 +95,20 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "current-versions",
+          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
+            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "AFTER_END_TIME",
             "orderPosition": 1
           },
           {
             "key": "future-versions",
+            "name": "Allocation for future-versions",
             "allocationEvaluationCode": "BEFORE_START_TIME",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -12,7 +12,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -50,7 +52,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -87,7 +91,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",

--- a/ufc/tests/test-flag-that-does-not-exist.json
+++ b/ufc/tests/test-flag-that-does-not-exist.json
@@ -12,7 +12,9 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -32,7 +34,9 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -51,7 +55,9 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environment": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,

--- a/ufc/tests/test-flag-that-does-not-exist.json
+++ b/ufc/tests/test-flag-that-does-not-exist.json
@@ -12,6 +12,7 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
+        "environment": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -31,6 +32,7 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
+        "environment": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -49,6 +51,7 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
+        "environment": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -31,6 +31,7 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -66,6 +67,7 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -100,6 +102,7 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },


### PR DESCRIPTION
Includes `environment` and `allocation.name` in UFC test data