### PR TITLE
Split test cases for dynamically-typed languages

### DIFF
--- a/ufc/bandit-tests/test-case-banner-bandit-uk-only.dynamic-typing.json
+++ b/ufc/bandit-tests/test-case-banner-bandit-uk-only.dynamic-typing.json
@@ -1,0 +1,112 @@
+{
+    "flag": "banner_bandit_flag_uk_only",
+    "defaultValue": "default",
+    "subjects": [
+      {
+        "subjectKey": "erica",
+        "subjectAttributes": {
+            "numericAttributes": {"age": 28, "account_age": 30},
+            "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
+        },
+        "actions": [
+            {
+                "actionKey": "nike",
+                "numericAttributes": {"brand_affinity": 1.2},
+                "categoricalAttributes": {"loyalty_tier": "platinum"}
+            },
+            {
+                "actionKey": "adidas",
+                "numericAttributes": {"brand_affinity": 1.0},
+                "categoricalAttributes": {"loyalty_tier": null}
+            },
+            {
+                "actionKey": "reebok",
+                "numericAttributes": {},
+                "categoricalAttributes": {}
+            },
+            {
+                "actionKey": "puma",
+                "numericAttributes": {
+                    "brand_affinity": 1.0,
+                    "discount": 0.1
+                },
+                "categoricalAttributes": {
+                    "color": "red"
+                }
+            }
+        ],
+        "assignment": {"variation": "control", "action": null}
+      },
+
+      {
+        "subjectKey": "frenkie",
+        "subjectAttributes": {
+            "numericAttributes": {"age": 31, "account_age": 4},
+            "categoricalAttributes": {"country": "Netherlands", "gender_identity": "male"}
+        },
+        "actions": [
+            {
+                "actionKey": "nike",
+                "numericAttributes": {"brand_affinity": 0.5},
+                "categoricalAttributes": {"loyalty_tier": "gold"}
+            },
+            {
+                "actionKey": "adidas",
+                "numericAttributes": {"brand_affinity": 0.0},
+                "categoricalAttributes": {"loyalty_tier": null}
+            },
+            {
+                "actionKey": "reebok",
+                "numericAttributes": {},
+                "categoricalAttributes": {}
+            },
+            {
+                "actionKey": "puma",
+                "numericAttributes": {
+                    "brand_affinity": 1.0,
+                    "discount": 0.1
+                },
+                "categoricalAttributes": {
+                    "color": "red"
+                }
+            }
+        ],
+        "assignment": {"variation": "control", "action": null}
+      },
+      {
+        "subjectKey": "gerard",
+        "subjectAttributes": {
+            "numericAttributes": {"age": null},
+            "categoricalAttributes": {"country": null, "gender_identity": null}
+        },
+        "actions": [
+            {
+                "actionKey": "nike",
+                "numericAttributes": {"brand_affinity": null},
+                "categoricalAttributes": {"loyalty_tier": null}
+            },
+            {
+                "actionKey": "adidas",
+                "numericAttributes": {"brand_affinity": 0.1},
+                "categoricalAttributes": {"loyalty_tier": null}
+            },
+            {
+                "actionKey": "reebok",
+                "numericAttributes": {},
+                "categoricalAttributes": {}
+            },
+            {
+                "actionKey": "puma",
+                "numericAttributes": {
+                    "brand_affinity": 1.0,
+                    "discount": 0.1
+                },
+                "categoricalAttributes": {
+                    "color": "red"
+                }
+            }
+        ],
+        "assignment": {"variation": "control", "action": null}
+      }
+    ]
+  }

--- a/ufc/bandit-tests/test-case-banner-bandit-uk-only.json
+++ b/ufc/bandit-tests/test-case-banner-bandit-uk-only.json
@@ -121,7 +121,7 @@
             {
                 "actionKey": "adidas",
                 "numericAttributes": {"brand_affinity": 1.0},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "reebok",
@@ -157,7 +157,7 @@
             {
                 "actionKey": "adidas",
                 "numericAttributes": {"brand_affinity": 0.0},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "reebok",
@@ -180,19 +180,19 @@
       {
         "subjectKey": "gerard",
         "subjectAttributes": {
-            "numericAttributes": {"age": null},
-            "categoricalAttributes": {"country": null, "gender_identity": null}
+            "numericAttributes": {},
+            "categoricalAttributes": {}
         },
         "actions": [
             {
                 "actionKey": "nike",
-                "numericAttributes": {"brand_affinity": null},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "numericAttributes": {},
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "adidas",
                 "numericAttributes": {"brand_affinity": 0.1},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "reebok",

--- a/ufc/bandit-tests/test-case-banner-bandit.dynamic-typing.json
+++ b/ufc/bandit-tests/test-case-banner-bandit.dynamic-typing.json
@@ -1,0 +1,165 @@
+{
+    "flag": "banner_bandit_flag",
+    "defaultValue": "default",
+    "subjects": [
+        {
+            "subjectKey": "henry",
+            "subjectAttributes": {
+                "numericAttributes": { "age": 25, "mistake": "oops" },
+                "categoricalAttributes": {"country": "USA", "gender_identity": "female", "area_code": 303}
+            },
+            "actions": [
+                {
+                    "actionKey": "nike",
+                    "numericAttributes": {"brand_affinity": -5},
+                    "categoricalAttributes": {"loyalty_tier": "silver"}
+                },
+                {
+                    "actionKey": "adidas",
+                    "numericAttributes": {"brand_affinity": 1.0},
+                    "categoricalAttributes": {"loyalty_tier": "bronze"}
+                },
+                {
+                    "actionKey": "reebok",
+                    "numericAttributes": {"brand_affinity": 20},
+                    "categoricalAttributes": {"loyalty_tier": "gold"}
+                }
+            ],
+            "assignment": {"variation": "banner_bandit", "action": "adidas"}
+        },
+
+        {
+            "subjectKey": "imogene",
+            "subjectAttributes": {
+                "numericAttributes": { "age": 25},
+                "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
+            },
+            "actions": [
+                {
+                    "actionKey": "nike",
+                    "numericAttributes": {"brand_affinity": -1.7, "mistake": true},
+                    "categoricalAttributes": {"loyalty_tier": "silver", "zip":  81427}
+                },
+                {
+                    "actionKey": "adidas",
+                    "numericAttributes": {"brand_affinity": 1.0},
+                    "categoricalAttributes": {"loyalty_tier": "bronze"}
+                },
+                {
+                    "actionKey": "reebok",
+                    "numericAttributes": {"brand_affinity": 15},
+                    "categoricalAttributes": {"loyalty_tier": "gold"}
+                }
+            ],
+            "assignment": {"variation": "banner_bandit", "action": "nike"}
+        },
+
+        {
+            "subjectKey": "erica",
+            "subjectAttributes": {
+                "numericAttributes": {"age": 28, "account_age": 30},
+                "categoricalAttributes": {"country": "USA", "gender_identity": "female"}
+            },
+            "actions": [
+                {
+                    "actionKey": "nike",
+                    "numericAttributes": {"brand_affinity": 1.2},
+                    "categoricalAttributes": {"loyalty_tier": "platinum"}
+                },
+                {
+                    "actionKey": "adidas",
+                    "numericAttributes": {"brand_affinity": 1.0},
+                    "categoricalAttributes": {"loyalty_tier": null}
+                },
+                {
+                    "actionKey": "reebok",
+                    "numericAttributes": {},
+                    "categoricalAttributes": {}
+                },
+                {
+                    "actionKey": "puma",
+                    "numericAttributes": {
+                        "brand_affinity": 1.0,
+                        "discount": 0.1
+                    },
+                    "categoricalAttributes": {
+                        "color": "red"
+                    }
+                }
+            ],
+            "assignment": {"variation": "default", "action": null}
+        },
+
+        {
+            "subjectKey": "frenkie",
+            "subjectAttributes": {
+                "numericAttributes": {"age": 31, "account_age": 4},
+                "categoricalAttributes": {"country": "Netherlands", "gender_identity": "male"}
+            },
+            "actions": [
+                {
+                    "actionKey": "nike",
+                    "numericAttributes": {"brand_affinity": 0.5},
+                    "categoricalAttributes": {"loyalty_tier": "gold"}
+                },
+                {
+                    "actionKey": "adidas",
+                    "numericAttributes": {"brand_affinity": 0.0},
+                    "categoricalAttributes": {"loyalty_tier": null}
+                },
+                {
+                    "actionKey": "reebok",
+                    "numericAttributes": {},
+                    "categoricalAttributes": {}
+                },
+                {
+                    "actionKey": "puma",
+                    "numericAttributes": {
+                        "brand_affinity": 1.0,
+                        "discount": 0.1
+                    },
+                    "categoricalAttributes": {
+                        "color": "red"
+                    }
+                }
+            ],
+            "assignment": {"variation": "banner_bandit", "action": "puma"}
+        },
+
+        {
+            "subjectKey": "gerard",
+            "subjectAttributes": {
+                "numericAttributes": {"age": null},
+                "categoricalAttributes": {"country": null, "gender_identity": null}
+            },
+            "actions": [
+                {
+                    "actionKey": "nike",
+                    "numericAttributes": {"brand_affinity": null},
+                    "categoricalAttributes": {"loyalty_tier": null}
+                },
+                {
+                    "actionKey": "adidas",
+                    "numericAttributes": {"brand_affinity": 0.1},
+                    "categoricalAttributes": {"loyalty_tier": null}
+                },
+                {
+                    "actionKey": "reebok",
+                    "numericAttributes": {},
+                    "categoricalAttributes": {}
+                },
+                {
+                    "actionKey": "puma",
+                    "numericAttributes": {
+                        "brand_affinity": 1.0,
+                        "discount": 0.1
+                    },
+                    "categoricalAttributes": {
+                        "color": "red"
+                    }
+                }
+            ],
+            "assignment": {"variation": "banner_bandit", "action": "nike"}
+        }
+    ]
+}

--- a/ufc/bandit-tests/test-case-banner-bandit.json
+++ b/ufc/bandit-tests/test-case-banner-bandit.json
@@ -121,7 +121,7 @@
             {
                 "actionKey": "adidas",
                 "numericAttributes": {"brand_affinity": 1.0},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "reebok",
@@ -157,7 +157,7 @@
             {
                 "actionKey": "adidas",
                 "numericAttributes": {"brand_affinity": 0.0},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "reebok",
@@ -180,19 +180,19 @@
       {
         "subjectKey": "gerard",
         "subjectAttributes": {
-            "numericAttributes": {"age": null},
-            "categoricalAttributes": {"country": null, "gender_identity": null}
+            "numericAttributes": {},
+            "categoricalAttributes": {}
         },
         "actions": [
             {
                 "actionKey": "nike",
-                "numericAttributes": {"brand_affinity": null},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "numericAttributes": {},
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "adidas",
                 "numericAttributes": {"brand_affinity": 0.1},
-                "categoricalAttributes": {"loyalty_tier": null}
+                "categoricalAttributes": {}
             },
             {
                 "actionKey": "reebok",
@@ -215,8 +215,8 @@
       {
         "subjectKey": "henry",
         "subjectAttributes": {
-          "numericAttributes": { "age": 25, "mistake": "oops" },
-          "categoricalAttributes": {"country": "USA", "gender_identity": "female", "area_code": 303}
+          "numericAttributes": { "age": 25 },
+          "categoricalAttributes": {"country": "USA", "gender_identity": "female", "area_code": "303"}
         },
         "actions": [
           {
@@ -246,8 +246,8 @@
         "actions": [
           {
             "actionKey": "nike",
-            "numericAttributes": {"brand_affinity": -1.7, "mistake": true},
-            "categoricalAttributes": {"loyalty_tier": "silver", "zip":  81427}
+            "numericAttributes": {"brand_affinity": -1.7},
+            "categoricalAttributes": {"loyalty_tier": "silver", "zip": "81427"}
           },
           {
             "actionKey": "adidas",


### PR DESCRIPTION
PR #36 added a couple of test cases for handling incorrectly-typed attributes. While these tests are important for dynamically-typed languages, they should be skipped in statically-typed languages because a type system ensures this input is impossible.

Having these test cases in the same file is problematic as it fails test file parsing and requires a lot of special handling just to skip offending test cases.

This commit copies such test cases into ".dynamic-typing.json" files (so they are easy to ignore) and removes/fixes offending data in original files (so statically-typed languages see same test cases).