### PR TITLE
Revert "FF-2526 fix tests for assignmentDetails object (#40)"

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -1,8 +1,5 @@
 {
     "createdAt": "2024-04-17T19:40:53.716Z",
-    "environment": {
-      "name": "Test"
-    },
     "flags": {
       "non_bandit_flag": {
         "key": "non_bandit_flag",
@@ -15,7 +12,6 @@
         "allocations": [
             {
                 "key": "control-allocation",
-                "name": "Allocation for control-allocation",
                 "splits": [
                     {
                         "variationKey": "control",
@@ -37,7 +33,6 @@
         "allocations": [
             {
                 "key": "control-allocation",
-                "name": "Allocation for control-allocation",
                 "splits": [
                     {
                         "variationKey": "control",
@@ -59,7 +54,6 @@
         "allocations": [
             {
                 "key": "analysis",
-                "name": "Allocation for analysis",
                 "splits": [
                     {
                         "variationKey": "control",
@@ -92,7 +86,6 @@
             },
             {
                 "key": "training",
-                "name": "Allocation for training",
                 "splits": [
                     {
                         "variationKey": "banner_bandit",
@@ -120,7 +113,6 @@
         "allocations": [
             {
                 "key": "training",
-                "name": "Allocation for training",
                 "rules": [
                     {
                       "conditions": [
@@ -144,7 +136,6 @@
             },
             {
                 "key": "default",
-                "name": "Allocation for default",
                 "rules": [],
                 "splits": [
                     {

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -1,8 +1,5 @@
 {
   "updatedAt": "2023-09-13T04:52:06.462Z",
-  "environment": {
-    "name": "Test"
-  },
   "bandits": {
     "banner_bandit": {
       "banditKey": "banner_bandit",

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,8 +1,5 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
-  "environment": {
-    "name": "Test"
-  },
   "flags": {
     "73fcc84c69e49e31fe16a29b2b1f803b": {
       "key": "73fcc84c69e49e31fe16a29b2b1f803b",
@@ -55,7 +52,6 @@
       "allocations": [
         {
           "key": "cm9sbG91dA==",
-          "name": "QWxsb2NhdGlvbiBmb3Igcm9sbG91dA==",
           "doLog": true,
           "splits": [
             {
@@ -84,7 +80,6 @@
       "allocations": [
         {
           "key": "dmFsaWQ=",
-          "name": "QWxsb2NhdGlvbiBmb3IgdmFsaWQ=",
           "doLog": true,
           "rules": [
             {
@@ -108,7 +103,6 @@
         },
         {
           "key": "aW52YWxpZA==",
-          "name": "QWxsb2NhdGlvbiBmb3IgaW52YWxpZA==",
           "doLog": true,
           "rules": [],
           "splits": [
@@ -138,7 +132,6 @@
       "allocations": [
         {
           "key": "cGFydGlhbC1leGFtcGxl",
-          "name": "QWxsb2NhdGlvbiBmb3IgcGFydGlhbC1leGFtcGxl",
           "doLog": true,
           "rules": [
             {
@@ -160,7 +153,6 @@
         },
         {
           "key": "dGVzdA==",
-          "name": "QWxsb2NhdGlvbiBmb3IgdGVzdA==",
           "doLog": true,
           "rules": [
             {
@@ -204,7 +196,6 @@
       "allocations": [
         {
           "key": "MS1mb3ItMQ==",
-          "name": "QWxsb2NhdGlvbiBmb3IgMS1mb3ItMQ==",
           "doLog": true,
           "rules": [
             {
@@ -228,7 +219,6 @@
         },
         {
           "key": "Mi1mb3ItMTIzNDU2Nzg5",
-          "name": "QWxsb2NhdGlvbiBmb3IgMi1mb3ItMTIzNDU2Nzg5",
           "doLog": true,
           "rules": [
             {
@@ -252,7 +242,6 @@
         },
         {
           "key": "My1mb3Itbm90LTI=",
-          "name": "QWxsb2NhdGlvbiBmb3IgMy1mb3Itbm90LTI=",
           "doLog": true,
           "rules": [
             {
@@ -306,7 +295,6 @@
       "allocations": [
         {
           "key": "MS1mb3Itb25lLW9m",
-          "name": "QWxsb2NhdGlvbiBmb3IgMS1mb3Itb25lLW9m",
           "doLog": true,
           "rules": [
             {
@@ -330,7 +318,6 @@
         },
         {
           "key": "Mi1mb3ItbWF0Y2hlcw==",
-          "name": "QWxsb2NhdGlvbiBmb3IgMi1mb3ItbWF0Y2hlcw==",
           "doLog": true,
           "rules": [
             {
@@ -352,7 +339,6 @@
         },
         {
           "key": "My1mb3Itbm90LW9uZS1vZg==",
-          "name": "QWxsb2NhdGlvbiBmb3IgMy1mb3Itbm90LW9uZS1vZg==",
           "doLog": true,
           "rules": [
             {
@@ -376,7 +362,6 @@
         },
         {
           "key": "NC1mb3Itbm90LW1hdGNoZXM=",
-          "name": "QWxsb2NhdGlvbiBmb3IgNC1mb3Itbm90LW1hdGNoZXM=",
           "doLog": true,
           "rules": [
             {
@@ -398,7 +383,6 @@
         },
         {
           "key": "NS1mb3ItbWF0Y2hlcy1udWxs",
-          "name": "QWxsb2NhdGlvbiBmb3IgNS1mb3ItbWF0Y2hlcy1udWxs",
           "doLog": true,
           "rules": [
             {
@@ -440,7 +424,6 @@
       "allocations": [
         {
           "key": "b24tZm9yLU5B",
-          "name": "QWxsb2NhdGlvbiBmb3Igb24tZm9yLU5B",
           "doLog": true,
           "rules": [
             {
@@ -476,7 +459,6 @@
         },
         {
           "key": "b24tZm9yLWFnZS01MCs=",
-          "name": "QWxsb2NhdGlvbiBmb3Igb24tZm9yLWFnZS01MCs=",
           "doLog": true,
           "rules": [
             {
@@ -508,7 +490,6 @@
         },
         {
           "key": "b2ZmLWZvci1hbGw=",
-          "name": "QWxsb2NhdGlvbiBmb3Igb2ZmLWZvci1hbGw=",
           "doLog": true,
           "rules": [],
           "splits": [
@@ -542,7 +523,6 @@
       "allocations": [
         {
           "key": "b2xkLXZlcnNpb25z",
-          "name": "QWxsb2NhdGlvbiBmb3Igb2xkLXZlcnNpb25z",
           "doLog": true,
           "rules": [
             {
@@ -564,7 +544,6 @@
         },
         {
           "key": "Y3VycmVudC12ZXJzaW9ucw==",
-          "name": "QWxsb2NhdGlvbiBmb3IgY3VycmVudC12ZXJzaW9ucw==",
           "doLog": true,
           "rules": [
             {
@@ -591,7 +570,6 @@
         },
         {
           "key": "bmV3LXZlcnNpb25z",
-          "name": "QWxsb2NhdGlvbiBmb3IgbmV3LXZlcnNpb25z",
           "doLog": true,
           "rules": [
             {
@@ -635,7 +613,6 @@
       "allocations": [
         {
           "key": "c21hbGwtc2l6ZQ==",
-          "name": "QWxsb2NhdGlvbiBmb3Igc21hbGwtc2l6ZQ==",
           "doLog": true,
           "rules": [
             {
@@ -657,7 +634,6 @@
         },
         {
           "key": "bWVkdW0tc2l6ZQ==",
-          "name": "QWxsb2NhdGlvbiBmb3IgbWVkdW0tc2l6ZQ==",
           "doLog": true,
           "rules": [
             {
@@ -684,7 +660,6 @@
         },
         {
           "key": "bGFyZ2Utc2l6ZQ==",
-          "name": "QWxsb2NhdGlvbiBmb3IgbGFyZ2Utc2l6ZQ==",
           "doLog": true,
           "rules": [
             {
@@ -728,7 +703,6 @@
       "allocations": [
         {
           "key": "b2xkLXZlcnNpb25z",
-          "name": "QWxsb2NhdGlvbiBmb3Igb2xkLXZlcnNpb25z",
           "doLog": true,
           "endAt": "MjAwMi0xMC0zMVQwOTowMDowMC41OTRa",
           "splits": [
@@ -740,7 +714,6 @@
         },
         {
           "key": "ZnV0dXJlLXZlcnNpb25z",
-          "name": "QWxsb2NhdGlvbiBmb3IgZnV0dXJlLXZlcnNpb25z",
           "doLog": true,
           "startAt": "MjA1Mi0xMC0zMVQwOTowMDowMC41OTRa",
           "splits": [
@@ -752,7 +725,6 @@
         },
         {
           "key": "Y3VycmVudC12ZXJzaW9ucw==",
-          "name": "QWxsb2NhdGlvbiBmb3IgY3VycmVudC12ZXJzaW9ucw==",
           "doLog": true,
           "startAt": "MjAyMi0xMC0zMVQwOTowMDowMC41OTRa",
           "endAt": "MjA1MC0xMC0zMVQwOTowMDowMC41OTRa",
@@ -783,7 +755,6 @@
       "allocations": [
         {
           "key": "bnVsbC1vcGVyYXRvcg==",
-          "name": "QWxsb2NhdGlvbiBmb3IgbnVsbC1vcGVyYXRvcg==",
           "doLog": true,
           "rules": [
             {
@@ -814,7 +785,6 @@
         },
         {
           "key": "bm90LW51bGwtb3BlcmF0b3I=",
-          "name": "QWxsb2NhdGlvbiBmb3Igbm90LW51bGwtb3BlcmF0b3I=",
           "doLog": true,
           "rules": [
             {
@@ -870,7 +840,6 @@
       "allocations": [
         {
           "key": "aWQgcnVsZQ==",
-          "name": "QWxsb2NhdGlvbiBmb3IgaWQgcnVsZQ==",
           "doLog": false,
           "rules": [
             {
@@ -892,7 +861,6 @@
         },
         {
           "key": "aW50ZXJuYWwgdXNlcnM=",
-          "name": "QWxsb2NhdGlvbiBmb3IgaW50ZXJuYWwgdXNlcnM=",
           "doLog": false,
           "rules": [
             {
@@ -914,7 +882,6 @@
         },
         {
           "key": "ZXhwZXJpbWVudA==",
-          "name": "QWxsb2NhdGlvbiBmb3IgZXhwZXJpbWVudA==",
           "doLog": true,
           "rules": [
             {
@@ -1005,7 +972,6 @@
         },
         {
           "key": "cm9sbG91dA==",
-          "name": "QWxsb2NhdGlvbiBmb3Igcm9sbG91dA==",
           "doLog": true,
           "rules": [
             {
@@ -1067,7 +1033,6 @@
       "allocations": [
         {
           "key": "dGFyZ2V0ZWQgYWxsb2NhdGlvbg==",
-          "name": "QWxsb2NhdGlvbiBmb3IgdGFyZ2V0ZWQgYWxsb2NhdGlvbg==",
           "doLog": true,
           "rules": [
             {
@@ -1112,7 +1077,6 @@
         },
         {
           "key": "NTAvNTAgc3BsaXQ=",
-          "name": "QWxsb2NhdGlvbiBmb3IgNTAvNTAgc3BsaXQ=",
           "doLog": true,
           "rules": [],
           "splits": [
@@ -1166,7 +1130,6 @@
       "allocations": [
         {
           "key": "NTAvNTAgc3BsaXQ=",
-          "name": "QWxsb2NhdGlvbiBmb3IgNTAvNTAgc3BsaXQ=",
           "doLog": true,
           "rules": [],
           "splits": [

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1,8 +1,5 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
-  "environment": {
-    "name": "Test"
-  },
   "flags": {
     "empty_flag": {
       "key": "empty_flag",
@@ -54,7 +51,6 @@
       "allocations": [
         {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "splits": [
             {
               "variationKey": "pi",
@@ -83,7 +79,6 @@
       "allocations": [
         {
           "key": "valid",
-          "name": "Allocation for valid",
           "rules": [
             {
               "conditions": [
@@ -107,7 +102,6 @@
         },
         {
           "key": "invalid",
-          "name": "Allocation for invalid",
           "rules": [],
           "splits": [
             {
@@ -137,7 +131,6 @@
       "allocations": [
         {
           "key": "partial-example",
-          "name": "Allocation for partial-example",
           "rules": [
             {
               "conditions": [
@@ -159,7 +152,6 @@
         },
         {
           "key": "test",
-          "name": "Allocation for test",
           "rules": [
             {
               "conditions": [
@@ -203,7 +195,6 @@
       "allocations": [
         {
           "key": "1-for-1",
-          "name": "Allocation for 1-for-1",
           "rules": [
             {
               "conditions": [
@@ -227,7 +218,6 @@
         },
         {
           "key": "2-for-123456789",
-          "name": "Allocation for 2-for-123456789",
           "rules": [
             {
               "conditions": [
@@ -251,7 +241,6 @@
         },
         {
           "key": "3-for-not-2",
-          "name": "Allocation for 3-for-not-2",
           "rules": [
             {
               "conditions": [
@@ -305,7 +294,6 @@
       "allocations": [
         {
           "key": "1-for-one-of",
-          "name": "Allocation for 1-for-one-of",
           "rules": [
             {
               "conditions": [
@@ -329,7 +317,6 @@
         },
         {
           "key": "2-for-matches",
-          "name": "Allocation for 2-for-matches",
           "rules": [
             {
               "conditions": [
@@ -351,7 +338,6 @@
         },
         {
           "key": "3-for-not-one-of",
-          "name": "Allocation for 3-for-not-one-of",
           "rules": [
             {
               "conditions": [
@@ -375,7 +361,6 @@
         },
         {
           "key": "4-for-not-matches",
-          "name": "Allocation for 4-for-not-matches",
           "rules": [
             {
               "conditions": [
@@ -397,7 +382,6 @@
         },
         {
           "key": "5-for-matches-null",
-          "name": "Allocation for 5-for-matches-null",
           "rules": [
             {
               "conditions": [
@@ -439,7 +423,6 @@
       "allocations": [
         {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "rules": [
             {
               "conditions": [
@@ -475,7 +458,6 @@
         },
         {
           "key": "on-for-age-50+",
-          "name": "Allocation for on-for-age-50+",
           "rules": [
             {
               "conditions": [
@@ -507,7 +489,6 @@
         },
         {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "rules": [],
           "splits": [
             {
@@ -541,7 +522,6 @@
       "allocations": [
         {
           "key": "old-versions",
-          "name": "Allocation for old-versions",
           "rules": [
             {
               "conditions": [
@@ -563,7 +543,6 @@
         },
         {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "rules": [
             {
               "conditions": [
@@ -590,7 +569,6 @@
         },
         {
           "key": "new-versions",
-          "name": "Allocation for new-versions",
           "rules": [
             {
               "conditions": [
@@ -634,7 +612,6 @@
       "allocations": [
         {
           "key": "small-size",
-          "name": "Allocation for small-size",
           "rules": [
             {
               "conditions": [
@@ -656,7 +633,6 @@
         },
         {
           "key": "medum-size",
-          "name": "Allocation for medum-size",
           "rules": [
             {
               "conditions": [
@@ -683,7 +659,6 @@
         },
         {
           "key": "large-size",
-          "name": "Allocation for large-size",
           "rules": [
             {
               "conditions": [
@@ -727,7 +702,6 @@
       "allocations": [
         {
           "key": "old-versions",
-          "name": "Allocation for old-versions",
           "splits": [
             {
               "variationKey": "old",
@@ -739,7 +713,6 @@
         },
         {
           "key": "future-versions",
-          "name": "Allocation for future-versions",
           "splits": [
             {
               "variationKey": "future",
@@ -751,7 +724,6 @@
         },
         {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "splits": [
             {
               "variationKey": "current",
@@ -782,7 +754,6 @@
       "allocations": [
         {
           "key": "null-operator",
-          "name": "Allocation for null-operator",
           "rules": [
             {
               "conditions": [
@@ -813,7 +784,6 @@
         },
         {
           "key": "not-null-operator",
-          "name": "Allocation for not-null-operator",
           "rules": [
             {
               "conditions": [
@@ -869,7 +839,6 @@
       "allocations": [
         {
           "key": "id rule",
-          "name": "Allocation for id rule",
           "rules": [
             {
               "conditions": [
@@ -891,7 +860,6 @@
         },
         {
           "key": "internal users",
-          "name": "Allocation for internal users",
           "rules": [
             {
               "conditions": [
@@ -913,7 +881,6 @@
         },
         {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "rules": [
             {
               "conditions": [
@@ -1004,7 +971,6 @@
         },
         {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "rules": [
             {
               "conditions": [
@@ -1066,7 +1032,6 @@
       "allocations": [
         {
           "key": "targeted allocation",
-          "name": "Allocation for targeted allocation",
           "rules": [
             {
               "conditions": [
@@ -1111,7 +1076,6 @@
         },
         {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "rules": [],
           "splits": [
             {
@@ -1165,7 +1129,6 @@
       "allocations": [
         {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "rules": [],
           "splits": [
             {

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -11,9 +11,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-one-of\".",
         "variationKey": "1",
@@ -31,7 +28,6 @@
         },
         "matchedAllocation": {
           "key": "1-for-one-of",
-          "name": "Allocation for 1-for-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -39,25 +35,21 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -72,9 +64,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -84,31 +73,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -124,9 +108,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -136,31 +117,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -176,9 +152,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-matches\".",
         "variationKey": "2",
@@ -194,14 +167,12 @@
         },
         "matchedAllocation": {
           "key": "2-for-matches",
-          "name": "Allocation for 2-for-matches",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -209,19 +180,16 @@
         "unevaluatedAllocations": [
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -236,9 +204,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -248,31 +213,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -288,9 +248,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -300,31 +257,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -340,9 +292,6 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -358,26 +307,22 @@
         },
         "matchedAllocation": {
           "key": "4-for-not-matches",
-          "name": "Allocation for 4-for-not-matches",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -385,7 +330,6 @@
         "unevaluatedAllocations": [
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -400,9 +344,6 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -418,26 +359,22 @@
         },
         "matchedAllocation": {
           "key": "4-for-not-matches",
-          "name": "Allocation for 4-for-not-matches",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -445,7 +382,6 @@
         "unevaluatedAllocations": [
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -460,9 +396,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -480,20 +413,17 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-one-of",
-          "name": "Allocation for 3-for-not-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -501,13 +431,11 @@
         "unevaluatedAllocations": [
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -522,9 +450,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -534,31 +459,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -574,9 +494,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -594,20 +511,17 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-one-of",
-          "name": "Allocation for 3-for-not-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -615,13 +529,11 @@
         "unevaluatedAllocations": [
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -636,9 +548,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -656,20 +565,17 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-one-of",
-          "name": "Allocation for 3-for-not-one-of",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -677,13 +583,11 @@
         "unevaluatedAllocations": [
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 5
           }
@@ -698,9 +602,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -710,31 +611,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -750,9 +646,6 @@
       "assignment": 5,
       "assignmentDetails": {
         "value": 5,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"5-for-matches-null\".",
         "variationKey": "5",
@@ -770,32 +663,27 @@
         },
         "matchedAllocation": {
           "key": "5-for-matches-null",
-          "name": "Allocation for 5-for-matches-null",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 5
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -811,9 +699,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -823,31 +708,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }
@@ -861,9 +741,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -873,31 +750,26 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-one-of",
-            "name": "Allocation for 1-for-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-matches",
-            "name": "Allocation for 2-for-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-one-of",
-            "name": "Allocation for 3-for-not-one-of",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "4-for-not-matches",
-            "name": "Allocation for 4-for-not-matches",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           },
           {
             "key": "5-for-matches-null",
-            "name": "Allocation for 5-for-matches-null",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 5
           }

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -11,7 +11,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-one-of\".",
         "variationKey": "1",
@@ -70,7 +72,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -120,7 +124,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -170,7 +176,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-matches\".",
         "variationKey": "2",
@@ -228,7 +236,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -278,7 +288,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -328,7 +340,9 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -386,7 +400,9 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -444,7 +460,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -504,7 +522,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -554,7 +574,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -614,7 +636,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -674,7 +698,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -724,7 +750,9 @@
       "assignment": 5,
       "assignmentDetails": {
         "value": 5,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"5-for-matches-null\".",
         "variationKey": "5",
@@ -783,7 +811,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -831,7 +861,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -12,9 +12,6 @@
       "assignment": "small",
       "assignmentDetails": {
         "value": "small",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"small-size\".",
         "variationKey": "small",
@@ -30,7 +27,6 @@
         },
         "matchedAllocation": {
           "key": "small-size",
-          "name": "Allocation for small-size",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -38,13 +34,11 @@
         "unevaluatedAllocations": [
           {
             "key": "medum-size",
-            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "large-size",
-            "name": "Allocation for large-size",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -60,9 +54,6 @@
       "assignment": "medium",
       "assignmentDetails": {
         "value": "medium",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"medum-size\".",
         "variationKey": "medium",
@@ -83,14 +74,12 @@
         },
         "matchedAllocation": {
           "key": "medum-size",
-          "name": "Allocation for medum-size",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "small-size",
-            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -98,7 +87,6 @@
         "unevaluatedAllocations": [
           {
             "key": "large-size",
-            "name": "Allocation for large-size",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -113,9 +101,6 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -125,19 +110,16 @@
         "unmatchedAllocations": [
           {
             "key": "small-size",
-            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "medum-size",
-            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "large-size",
-            "name": "Allocation for large-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -153,9 +135,6 @@
       "assignment": "large",
       "assignmentDetails": {
         "value": "large",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"large-size\".",
         "variationKey": "large",
@@ -171,20 +150,17 @@
         },
         "matchedAllocation": {
           "key": "large-size",
-          "name": "Allocation for large-size",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "small-size",
-            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "medum-size",
-            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -200,9 +176,6 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -212,19 +185,16 @@
         "unmatchedAllocations": [
           {
             "key": "small-size",
-            "name": "Allocation for small-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "medum-size",
-            "name": "Allocation for medum-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "large-size",
-            "name": "Allocation for large-size",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -12,7 +12,9 @@
       "assignment": "small",
       "assignmentDetails": {
         "value": "small",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"small-size\".",
         "variationKey": "small",
@@ -58,7 +60,9 @@
       "assignment": "medium",
       "assignmentDetails": {
         "value": "medium",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"medum-size\".",
         "variationKey": "medium",
@@ -109,7 +113,9 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -147,7 +153,9 @@
       "assignment": "large",
       "assignmentDetails": {
         "value": "large",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"large-size\".",
         "variationKey": "large",
@@ -192,7 +200,9 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-disabled-flag.json
+++ b/ufc/tests/test-case-disabled-flag.json
@@ -12,7 +12,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -32,7 +34,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -51,7 +55,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,

--- a/ufc/tests/test-case-disabled-flag.json
+++ b/ufc/tests/test-case-disabled-flag.json
@@ -12,9 +12,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -34,9 +31,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -55,9 +49,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,

--- a/ufc/tests/test-case-empty-flag.json
+++ b/ufc/tests/test-case-empty-flag.json
@@ -12,9 +12,6 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -34,9 +31,6 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -55,9 +49,6 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-empty-flag.json
+++ b/ufc/tests/test-case-empty-flag.json
@@ -12,7 +12,9 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -32,7 +34,9 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -51,7 +55,9 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -12,7 +12,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -56,7 +58,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -99,7 +103,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -132,7 +138,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -173,7 +181,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -202,7 +212,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "2 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -231,7 +243,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "3 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -260,7 +274,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -289,7 +305,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -318,7 +336,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -347,7 +367,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "7 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -376,7 +398,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "8 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -405,7 +429,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -434,7 +460,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -463,7 +491,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -492,7 +522,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "12 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -521,7 +553,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "13 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -550,7 +584,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -579,7 +615,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -608,7 +646,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -637,7 +677,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -666,7 +708,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -695,7 +739,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -12,9 +12,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -34,7 +31,6 @@
         },
         "matchedAllocation": {
           "key": "targeted allocation",
-          "name": "Allocation for targeted allocation",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -42,7 +38,6 @@
         "unevaluatedAllocations": [
           {
             "key": "50/50 split",
-            "name": "Allocation for 50/50 split",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -58,9 +53,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -80,7 +72,6 @@
         },
         "matchedAllocation": {
           "key": "targeted allocation",
-          "name": "Allocation for targeted allocation",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -88,7 +79,6 @@
         "unevaluatedAllocations": [
           {
             "key": "50/50 split",
-            "name": "Allocation for 50/50 split",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -103,9 +93,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -113,14 +100,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -138,9 +123,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -160,7 +142,6 @@
         },
         "matchedAllocation": {
           "key": "targeted allocation",
-          "name": "Allocation for targeted allocation",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -168,7 +149,6 @@
         "unevaluatedAllocations": [
           {
             "key": "50/50 split",
-            "name": "Allocation for 50/50 split",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -181,9 +161,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -191,14 +168,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -212,9 +187,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "2 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -222,14 +194,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -243,9 +213,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "3 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -253,14 +220,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -274,9 +239,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -284,14 +246,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -305,9 +265,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -315,14 +272,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -336,9 +291,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -346,14 +298,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -367,9 +317,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "7 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -377,14 +324,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -398,9 +343,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "8 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -408,14 +350,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -429,9 +369,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -439,14 +376,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -460,9 +395,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -470,14 +402,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -491,9 +421,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -501,14 +428,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -522,9 +447,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "12 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -532,14 +454,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -553,9 +473,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "13 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -563,14 +480,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -584,9 +499,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -594,14 +506,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -615,9 +525,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -625,14 +532,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -646,9 +551,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -656,14 +558,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -677,9 +577,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -687,14 +584,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -708,9 +603,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -718,14 +610,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -739,9 +629,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -749,14 +636,12 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "targeted allocation",
-            "name": "Allocation for targeted allocation",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -12,9 +12,6 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,
@@ -25,13 +22,11 @@
         "unevaluatedAllocations": [
           {
             "key": "valid",
-            "name": "Allocation for valid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 1
           },
           {
             "key": "invalid",
-            "name": "Allocation for invalid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -47,9 +42,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"valid\".",
         "variationKey": "one",
@@ -67,7 +59,6 @@
         },
         "matchedAllocation": {
           "key": "valid",
-          "name": "Allocation for valid",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -75,7 +66,6 @@
         "unevaluatedAllocations": [
           {
             "key": "invalid",
-            "name": "Allocation for invalid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -90,9 +80,6 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,
@@ -103,13 +90,11 @@
         "unevaluatedAllocations": [
           {
             "key": "valid",
-            "name": "Allocation for valid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 1
           },
           {
             "key": "invalid",
-            "name": "Allocation for invalid",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -12,7 +12,9 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,
@@ -45,7 +47,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"valid\".",
         "variationKey": "one",
@@ -86,7 +90,9 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,

--- a/ufc/tests/test-case-kill-switch-flag.json
+++ b/ufc/tests/test-case-kill-switch-flag.json
@@ -12,9 +12,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -34,7 +31,6 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -42,13 +38,11 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -64,9 +58,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -86,7 +77,6 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -94,13 +84,11 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -116,9 +104,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "barbara belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -126,20 +111,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -155,9 +137,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -165,20 +144,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -196,9 +172,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -218,7 +191,6 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -226,13 +198,11 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -245,9 +215,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -255,20 +222,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -284,9 +248,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -306,7 +267,6 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -314,13 +274,11 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -336,9 +294,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -354,14 +309,12 @@
         },
         "matchedAllocation": {
           "key": "on-for-age-50+",
-          "name": "Allocation for on-for-age-50+",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -369,7 +322,6 @@
         "unevaluatedAllocations": [
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -384,9 +336,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -394,20 +343,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -423,9 +369,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -433,20 +376,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -462,9 +402,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -472,20 +409,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -502,9 +436,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -524,7 +455,6 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -532,13 +462,11 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -554,9 +482,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -572,14 +497,12 @@
         },
         "matchedAllocation": {
           "key": "on-for-age-50+",
-          "name": "Allocation for on-for-age-50+",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -587,7 +510,6 @@
         "unevaluatedAllocations": [
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -602,9 +524,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -612,20 +531,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -639,9 +555,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -649,20 +562,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -676,9 +586,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -686,20 +593,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -715,9 +619,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -737,7 +638,6 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -745,13 +645,11 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -766,9 +664,6 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -788,7 +683,6 @@
         },
         "matchedAllocation": {
           "key": "on-for-NA",
-          "name": "Allocation for on-for-NA",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -796,13 +690,11 @@
         "unevaluatedAllocations": [
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "off-for-all",
-            "name": "Allocation for off-for-all",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -815,9 +707,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -825,20 +714,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -854,9 +740,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -864,20 +747,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -893,9 +773,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -903,20 +780,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -932,9 +806,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -942,20 +813,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -971,9 +839,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -981,20 +846,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1010,9 +872,6 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -1020,20 +879,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "off-for-all",
-          "name": "Allocation for off-for-all",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "on-for-NA",
-            "name": "Allocation for on-for-NA",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "on-for-age-50+",
-            "name": "Allocation for on-for-age-50+",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-kill-switch-flag.json
+++ b/ufc/tests/test-case-kill-switch-flag.json
@@ -12,7 +12,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -62,7 +64,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -112,7 +116,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "barbara belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -149,7 +155,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -188,7 +196,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -235,7 +245,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -272,7 +284,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -322,7 +336,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -368,7 +384,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -405,7 +423,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -442,7 +462,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -480,7 +502,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -530,7 +554,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -576,7 +602,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -611,7 +639,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -646,7 +676,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -683,7 +715,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -732,7 +766,9 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -779,7 +815,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -816,7 +854,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -853,7 +893,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -890,7 +932,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -927,7 +971,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -964,7 +1010,9 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",

--- a/ufc/tests/test-case-new-user-onboarding-flag.json
+++ b/ufc/tests/test-case-new-user-onboarding-flag.json
@@ -12,9 +12,6 @@
       "assignment": "green",
       "assignmentDetails": {
         "value": "green",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"internal users\".",
         "variationKey": "green",
@@ -30,14 +27,12 @@
         },
         "matchedAllocation": {
           "key": "internal users",
-          "name": "Allocation for internal users",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -45,13 +40,11 @@
         "unevaluatedAllocations": [
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -67,9 +60,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -79,25 +69,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
             "orderPosition": 4
           }
@@ -113,9 +99,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -125,25 +108,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -161,9 +140,6 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -183,26 +159,22 @@
         },
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -220,9 +192,6 @@
       "assignment": "purple",
       "assignmentDetails": {
         "value": "purple",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"id rule\".",
         "variationKey": "purple",
@@ -238,7 +207,6 @@
         },
         "matchedAllocation": {
           "key": "id rule",
-          "name": "Allocation for id rule",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -246,19 +214,16 @@
         "unevaluatedAllocations": [
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -276,9 +241,6 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -298,26 +260,22 @@
         },
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -335,9 +293,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -347,25 +302,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
             "orderPosition": 4
           }
@@ -379,9 +330,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -391,25 +339,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -425,9 +369,6 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -447,26 +388,22 @@
         },
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -483,9 +420,6 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 3 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -505,20 +439,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -526,7 +457,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -541,9 +471,6 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 4 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -563,20 +490,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -584,7 +508,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -599,9 +522,6 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 5 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -621,20 +541,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -642,7 +559,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -657,9 +573,6 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 6 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -679,20 +592,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -700,7 +610,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -715,9 +624,6 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -737,26 +643,22 @@
         },
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -772,9 +674,6 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 8 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -794,20 +693,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -815,7 +711,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -830,9 +725,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -842,25 +734,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -874,9 +762,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -886,25 +771,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -918,9 +799,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -930,25 +808,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -964,9 +838,6 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -986,26 +857,22 @@
         },
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -1021,9 +888,6 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -1043,26 +907,22 @@
         },
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 4
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -1076,9 +936,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1088,25 +945,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -1122,9 +975,6 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 15 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -1144,20 +994,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1165,7 +1012,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -1180,9 +1026,6 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 16 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1202,20 +1045,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1223,7 +1063,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -1238,9 +1077,6 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 17 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1260,20 +1096,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1281,7 +1114,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }
@@ -1296,9 +1128,6 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1308,25 +1137,21 @@
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "experiment",
-            "name": "Allocation for experiment",
             "allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
             "orderPosition": 3
           },
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 4
           }
@@ -1342,9 +1167,6 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 19 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -1364,20 +1186,17 @@
         },
         "matchedAllocation": {
           "key": "experiment",
-          "name": "Allocation for experiment",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "id rule",
-            "name": "Allocation for id rule",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "internal users",
-            "name": "Allocation for internal users",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -1385,7 +1204,6 @@
         "unevaluatedAllocations": [
           {
             "key": "rollout",
-            "name": "Allocation for rollout",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 4
           }

--- a/ufc/tests/test-case-new-user-onboarding-flag.json
+++ b/ufc/tests/test-case-new-user-onboarding-flag.json
@@ -12,7 +12,9 @@
       "assignment": "green",
       "assignmentDetails": {
         "value": "green",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"internal users\".",
         "variationKey": "green",
@@ -65,7 +67,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -109,7 +113,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -155,7 +161,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -212,7 +220,9 @@
       "assignment": "purple",
       "assignmentDetails": {
         "value": "purple",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"id rule\".",
         "variationKey": "purple",
@@ -266,7 +276,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -323,7 +335,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -365,7 +379,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -409,7 +425,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -465,7 +483,9 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 3 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -521,7 +541,9 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 4 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -577,7 +599,9 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 5 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -633,7 +657,9 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 6 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -689,7 +715,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -744,7 +772,9 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 8 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -800,7 +830,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -842,7 +874,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -884,7 +918,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -928,7 +964,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -983,7 +1021,9 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -1036,7 +1076,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1080,7 +1122,9 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 15 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -1136,7 +1180,9 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 16 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1192,7 +1238,9 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 17 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1248,7 +1296,9 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1292,7 +1342,9 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 19 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -12,9 +12,6 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -30,7 +27,6 @@
         },
         "matchedAllocation": {
           "key": "null-operator",
-          "name": "Allocation for null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -38,7 +34,6 @@
         "unevaluatedAllocations": [
           {
             "key": "not-null-operator",
-            "name": "Allocation for not-null-operator",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -54,9 +49,6 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -72,14 +64,12 @@
         },
         "matchedAllocation": {
           "key": "not-null-operator",
-          "name": "Allocation for not-null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "null-operator",
-            "name": "Allocation for null-operator",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -95,9 +85,6 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -113,7 +100,6 @@
         },
         "matchedAllocation": {
           "key": "null-operator",
-          "name": "Allocation for null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -121,7 +107,6 @@
         "unevaluatedAllocations": [
           {
             "key": "not-null-operator",
-            "name": "Allocation for not-null-operator",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -136,9 +121,6 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -154,14 +136,12 @@
         },
         "matchedAllocation": {
           "key": "not-null-operator",
-          "name": "Allocation for not-null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "null-operator",
-            "name": "Allocation for null-operator",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -177,9 +157,6 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -195,7 +172,6 @@
         },
         "matchedAllocation": {
           "key": "null-operator",
-          "name": "Allocation for null-operator",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -203,7 +179,6 @@
         "unevaluatedAllocations": [
           {
             "key": "not-null-operator",
-            "name": "Allocation for not-null-operator",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -12,7 +12,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -52,7 +54,9 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -91,7 +95,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -130,7 +136,9 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -169,7 +177,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",

--- a/ufc/tests/test-case-numeric-flag.json
+++ b/ufc/tests/test-case-numeric-flag.json
@@ -12,9 +12,6 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -22,7 +19,6 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -39,9 +35,6 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -49,7 +42,6 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -65,9 +57,6 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -75,7 +64,6 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "rollout",
-          "name": "Allocation for rollout",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },

--- a/ufc/tests/test-case-numeric-flag.json
+++ b/ufc/tests/test-case-numeric-flag.json
@@ -12,7 +12,9 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -37,7 +39,9 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -61,7 +65,9 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",

--- a/ufc/tests/test-case-numeric-one-of.json
+++ b/ufc/tests/test-case-numeric-one-of.json
@@ -11,7 +11,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -58,7 +60,9 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -96,7 +100,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -143,7 +149,9 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -190,7 +198,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -237,7 +247,9 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -284,7 +296,9 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-123456789\".",
         "variationKey": "2",

--- a/ufc/tests/test-case-numeric-one-of.json
+++ b/ufc/tests/test-case-numeric-one-of.json
@@ -11,9 +11,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -31,7 +28,6 @@
         },
         "matchedAllocation": {
           "key": "1-for-1",
-          "name": "Allocation for 1-for-1",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -39,13 +35,11 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-123456789",
-            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
-            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -60,9 +54,6 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -72,19 +63,16 @@
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
-            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-123456789",
-            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
-            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -100,9 +88,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -120,20 +105,17 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-2",
-          "name": "Allocation for 3-for-not-2",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
-            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-123456789",
-            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -149,9 +131,6 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -169,20 +148,17 @@
         },
         "matchedAllocation": {
           "key": "3-for-not-2",
-          "name": "Allocation for 3-for-not-2",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
-            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "2-for-123456789",
-            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -198,9 +174,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -218,7 +191,6 @@
         },
         "matchedAllocation": {
           "key": "1-for-1",
-          "name": "Allocation for 1-for-1",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -226,13 +198,11 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-123456789",
-            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
-            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -247,9 +217,6 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -267,7 +234,6 @@
         },
         "matchedAllocation": {
           "key": "1-for-1",
-          "name": "Allocation for 1-for-1",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -275,13 +241,11 @@
         "unevaluatedAllocations": [
           {
             "key": "2-for-123456789",
-            "name": "Allocation for 2-for-123456789",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "3-for-not-2",
-            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -296,9 +260,6 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-123456789\".",
         "variationKey": "2",
@@ -316,14 +277,12 @@
         },
         "matchedAllocation": {
           "key": "2-for-123456789",
-          "name": "Allocation for 2-for-123456789",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "1-for-1",
-            "name": "Allocation for 1-for-1",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -331,7 +290,6 @@
         "unevaluatedAllocations": [
           {
             "key": "3-for-not-2",
-            "name": "Allocation for 3-for-not-2",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }

--- a/ufc/tests/test-case-regex-flag.json
+++ b/ufc/tests/test-case-regex-flag.json
@@ -12,7 +12,9 @@
       "assignment": "partial-example",
       "assignmentDetails": {
         "value": "partial-example",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"partial-example\".",
         "variationKey": "partial-example",
@@ -52,7 +54,9 @@
       "assignment": "test",
       "assignmentDetails": {
         "value": "test",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"test\".",
         "variationKey": "test",
@@ -91,7 +95,9 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -124,7 +130,9 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-regex-flag.json
+++ b/ufc/tests/test-case-regex-flag.json
@@ -12,9 +12,6 @@
       "assignment": "partial-example",
       "assignmentDetails": {
         "value": "partial-example",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"partial-example\".",
         "variationKey": "partial-example",
@@ -30,7 +27,6 @@
         },
         "matchedAllocation": {
           "key": "partial-example",
-          "name": "Allocation for partial-example",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -38,7 +34,6 @@
         "unevaluatedAllocations": [
           {
             "key": "test",
-            "name": "Allocation for test",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           }
@@ -54,9 +49,6 @@
       "assignment": "test",
       "assignmentDetails": {
         "value": "test",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"test\".",
         "variationKey": "test",
@@ -72,14 +64,12 @@
         },
         "matchedAllocation": {
           "key": "test",
-          "name": "Allocation for test",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "partial-example",
-            "name": "Allocation for partial-example",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -95,9 +85,6 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -107,13 +94,11 @@
         "unmatchedAllocations": [
           {
             "key": "partial-example",
-            "name": "Allocation for partial-example",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "test",
-            "name": "Allocation for test",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -130,9 +115,6 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -142,13 +124,11 @@
         "unmatchedAllocations": [
           {
             "key": "partial-example",
-            "name": "Allocation for partial-example",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "test",
-            "name": "Allocation for test",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -12,7 +12,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -64,7 +66,9 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"old-versions\".",
         "variationKey": "old",
@@ -109,7 +113,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -160,7 +166,9 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -198,7 +206,9 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"new-versions\".",
         "variationKey": "new",
@@ -243,7 +253,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -12,9 +12,6 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -35,14 +32,12 @@
         },
         "matchedAllocation": {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -50,7 +45,6 @@
         "unevaluatedAllocations": [
           {
             "key": "new-versions",
-            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -66,9 +60,6 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"old-versions\".",
         "variationKey": "old",
@@ -84,7 +75,6 @@
         },
         "matchedAllocation": {
           "key": "old-versions",
-          "name": "Allocation for old-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -92,13 +82,11 @@
         "unevaluatedAllocations": [
           {
             "key": "current-versions",
-            "name": "Allocation for current-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 2
           },
           {
             "key": "new-versions",
-            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -113,9 +101,6 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -136,14 +121,12 @@
         },
         "matchedAllocation": {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -151,7 +134,6 @@
         "unevaluatedAllocations": [
           {
             "key": "new-versions",
-            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }
@@ -166,9 +148,6 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -178,19 +157,16 @@
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "current-versions",
-            "name": "Allocation for current-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           },
           {
             "key": "new-versions",
-            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 3
           }
@@ -206,9 +182,6 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"new-versions\".",
         "variationKey": "new",
@@ -224,20 +197,17 @@
         },
         "matchedAllocation": {
           "key": "new-versions",
-          "name": "Allocation for new-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           },
           {
             "key": "current-versions",
-            "name": "Allocation for current-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 2
           }
@@ -253,9 +223,6 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -276,14 +243,12 @@
         },
         "matchedAllocation": {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
           }
@@ -291,7 +256,6 @@
         "unevaluatedAllocations": [
           {
             "key": "new-versions",
-            "name": "Allocation for new-versions",
             "allocationEvaluationCode": "UNEVALUATED",
             "orderPosition": 3
           }

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -12,7 +12,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -50,7 +52,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -87,7 +91,9 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -12,9 +12,6 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -22,20 +19,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "AFTER_END_TIME",
             "orderPosition": 1
           },
           {
             "key": "future-versions",
-            "name": "Allocation for future-versions",
             "allocationEvaluationCode": "BEFORE_START_TIME",
             "orderPosition": 2
           }
@@ -52,9 +46,6 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -62,20 +53,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "AFTER_END_TIME",
             "orderPosition": 1
           },
           {
             "key": "future-versions",
-            "name": "Allocation for future-versions",
             "allocationEvaluationCode": "BEFORE_START_TIME",
             "orderPosition": 2
           }
@@ -91,9 +79,6 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -101,20 +86,17 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "current-versions",
-          "name": "Allocation for current-versions",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 3
         },
         "unmatchedAllocations": [
           {
             "key": "old-versions",
-            "name": "Allocation for old-versions",
             "allocationEvaluationCode": "AFTER_END_TIME",
             "orderPosition": 1
           },
           {
             "key": "future-versions",
-            "name": "Allocation for future-versions",
             "allocationEvaluationCode": "BEFORE_START_TIME",
             "orderPosition": 2
           }

--- a/ufc/tests/test-flag-that-does-not-exist.json
+++ b/ufc/tests/test-flag-that-does-not-exist.json
@@ -12,7 +12,9 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -32,7 +34,9 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -51,7 +55,9 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environmentName": "Test",
+        "environment": {
+          "name": "Test"
+        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,

--- a/ufc/tests/test-flag-that-does-not-exist.json
+++ b/ufc/tests/test-flag-that-does-not-exist.json
@@ -12,9 +12,6 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -34,9 +31,6 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -55,9 +49,6 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
-        "environment": {
-          "name": "Test"
-        },
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -31,7 +31,6 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -67,7 +66,6 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },
@@ -102,7 +100,6 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
-          "name": "Allocation for 50/50 split",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },


### PR DESCRIPTION
Reverts allocation.name (see thread https://eppo-group.slack.com/archives/C06N7AA6M5F/p1719864923087059?thread_ts=1719438261.986839&cid=C06N7AA6M5F)

This reverts commit e169514d1c6e91bec6cd89fa956d18846573fcd3.