### PR TITLE
Fix up the zip code as a categorical attribute test

### DIFF
--- a/ufc/bandit-tests/test-case-banner-bandit.dynamic-typing.json
+++ b/ufc/bandit-tests/test-case-banner-bandit.dynamic-typing.json
@@ -37,12 +37,12 @@
             "actions": [
                 {
                     "actionKey": "nike",
-                    "numericAttributes": {"brand_affinity": -1.7, "mistake": true},
+                    "numericAttributes": {"brand_affinity": -15, "mistake": true},
                     "categoricalAttributes": {"loyalty_tier": "silver", "zip":  81427}
                 },
                 {
                     "actionKey": "adidas",
-                    "numericAttributes": {"brand_affinity": 1.0},
+                    "numericAttributes": {"brand_affinity": 0.0},
                     "categoricalAttributes": {"loyalty_tier": "bronze"}
                 },
                 {

--- a/ufc/bandit-tests/test-case-banner-bandit.json
+++ b/ufc/bandit-tests/test-case-banner-bandit.json
@@ -246,12 +246,12 @@
         "actions": [
           {
             "actionKey": "nike",
-            "numericAttributes": {"brand_affinity": -1.7},
+            "numericAttributes": {"brand_affinity": -15},
             "categoricalAttributes": {"loyalty_tier": "silver", "zip": "81427"}
           },
           {
             "actionKey": "adidas",
-            "numericAttributes": {"brand_affinity": 1.0},
+            "numericAttributes": {"brand_affinity": 0.0},
             "categoricalAttributes": {"loyalty_tier": "bronze"}
           },
           {


### PR DESCRIPTION
Use values such that a different action will be selected if zip code is treated as numeric instead of categorical.

This was proved out for a JavaScript-client-specific test in [this PR](https://github.com/Eppo-exp/js-client-sdk-common/pull/108/files#diff-c3451b91ff71fe92808fe19fd6c58fe9dece0f29837d534e1ca186516153226fR302).