### PR TITLE
FF-2526 Test data for environment as part of UFC response

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -1,5 +1,8 @@
 {
     "createdAt": "2024-04-17T19:40:53.716Z",
+    "environment": {
+      "name": "Test"
+    },
     "flags": {
       "non_bandit_flag": {
         "key": "non_bandit_flag",

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -1,5 +1,8 @@
 {
   "updatedAt": "2023-09-13T04:52:06.462Z",
+  "environment": {
+    "name": "Test"
+  },
   "bandits": {
     "banner_bandit": {
       "banditKey": "banner_bandit",

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,5 +1,8 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
+  "environment": {
+    "name": "Test"
+  },
   "flags": {
     "73fcc84c69e49e31fe16a29b2b1f803b": {
       "key": "73fcc84c69e49e31fe16a29b2b1f803b",

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1,5 +1,8 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
+  "environment": {
+    "name": "Test"
+  },
   "flags": {
     "empty_flag": {
       "key": "empty_flag",

--- a/ufc/tests/test-case-boolean-one-of-matches.json
+++ b/ufc/tests/test-case-boolean-one-of-matches.json
@@ -11,6 +11,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-one-of\".",
         "variationKey": "1",
@@ -64,6 +65,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -108,6 +110,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -152,6 +155,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-matches\".",
         "variationKey": "2",
@@ -204,6 +208,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -248,6 +253,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -292,6 +298,7 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -344,6 +351,7 @@
       "assignment": 4,
       "assignmentDetails": {
         "value": 4,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"4-for-not-matches\".",
         "variationKey": "4",
@@ -396,6 +404,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -450,6 +459,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -494,6 +504,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -548,6 +559,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-one-of\".",
         "variationKey": "3",
@@ -602,6 +614,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -646,6 +659,7 @@
       "assignment": 5,
       "assignmentDetails": {
         "value": 5,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"5-for-matches-null\".",
         "variationKey": "5",
@@ -699,6 +713,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -741,6 +756,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-comparator-operator-flag.json
+++ b/ufc/tests/test-case-comparator-operator-flag.json
@@ -12,6 +12,7 @@
       "assignment": "small",
       "assignmentDetails": {
         "value": "small",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"small-size\".",
         "variationKey": "small",
@@ -54,6 +55,7 @@
       "assignment": "medium",
       "assignmentDetails": {
         "value": "medium",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"medum-size\".",
         "variationKey": "medium",
@@ -101,6 +103,7 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -135,6 +138,7 @@
       "assignment": "large",
       "assignmentDetails": {
         "value": "large",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"large-size\".",
         "variationKey": "large",
@@ -176,6 +180,7 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-disabled-flag.json
+++ b/ufc/tests/test-case-disabled-flag.json
@@ -12,6 +12,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -31,6 +32,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,
@@ -49,6 +51,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: disabled_flag",
         "variationKey": null,

--- a/ufc/tests/test-case-empty-flag.json
+++ b/ufc/tests/test-case-empty-flag.json
@@ -12,6 +12,7 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -31,6 +32,7 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -49,6 +51,7 @@
       "assignment": "default_value",
       "assignmentDetails": {
         "value": "default_value",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -12,6 +12,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -53,6 +54,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -93,6 +95,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -123,6 +126,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"targeted allocation\".",
         "variationKey": "three",
@@ -161,6 +165,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -187,6 +192,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "2 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -213,6 +219,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "3 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -239,6 +246,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -265,6 +273,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -291,6 +300,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -317,6 +327,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "7 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -343,6 +354,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "8 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -369,6 +381,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -395,6 +408,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -421,6 +435,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -447,6 +462,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "12 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -473,6 +489,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "13 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -499,6 +516,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -525,6 +543,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -551,6 +570,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
         "variationKey": "two",
@@ -577,6 +597,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -603,6 +624,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",
@@ -629,6 +651,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
         "variationKey": "one",

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -12,6 +12,7 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
+        "environmentName": "Test",
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,
@@ -42,6 +43,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"valid\".",
         "variationKey": "one",
@@ -80,6 +82,7 @@
       "assignment": 42,
       "assignmentDetails": {
         "value": 42,
+        "environmentName": "Test",
         "flagEvaluationCode": "TYPE_MISMATCH",
         "flagEvaluationDescription": "Expected variation type INTEGER does not match for variation 'pi' with value 3.1415926",
         "variationKey": null,

--- a/ufc/tests/test-case-kill-switch-flag.json
+++ b/ufc/tests/test-case-kill-switch-flag.json
@@ -12,6 +12,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -58,6 +59,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -104,6 +106,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "barbara belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -137,6 +140,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -172,6 +176,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -215,6 +220,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "1 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -248,6 +254,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -294,6 +301,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -336,6 +344,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "4 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -369,6 +378,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "5 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -402,6 +412,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "6 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -436,6 +447,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -482,6 +494,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-age-50+\".",
         "variationKey": "on",
@@ -524,6 +537,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "9 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -555,6 +569,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "10 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -586,6 +601,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "11 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -619,6 +635,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -664,6 +681,7 @@
       "assignment": true,
       "assignmentDetails": {
         "value": true,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"on-for-NA\".",
         "variationKey": "on",
@@ -707,6 +725,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "14 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -740,6 +759,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "15 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -773,6 +793,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "16 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -806,6 +827,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "17 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -839,6 +861,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "18 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",
@@ -872,6 +895,7 @@
       "assignment": false,
       "assignmentDetails": {
         "value": false,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "19 belongs to the range of traffic assigned to \"off\" defined in allocation \"off-for-all\".",
         "variationKey": "off",

--- a/ufc/tests/test-case-new-user-onboarding-flag.json
+++ b/ufc/tests/test-case-new-user-onboarding-flag.json
@@ -12,6 +12,7 @@
       "assignment": "green",
       "assignmentDetails": {
         "value": "green",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"internal users\".",
         "variationKey": "green",
@@ -60,6 +61,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -99,6 +101,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -140,6 +143,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -192,6 +196,7 @@
       "assignment": "purple",
       "assignmentDetails": {
         "value": "purple",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"id rule\".",
         "variationKey": "purple",
@@ -241,6 +246,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -293,6 +299,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -330,6 +337,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -369,6 +377,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -420,6 +429,7 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 3 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -471,6 +481,7 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 4 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -522,6 +533,7 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 5 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -573,6 +585,7 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 6 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -624,6 +637,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -674,6 +688,7 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 8 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",
@@ -725,6 +740,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -762,6 +778,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -799,6 +816,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -838,6 +856,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -888,6 +907,7 @@
       "assignment": "blue",
       "assignmentDetails": {
         "value": "blue",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"rollout\".",
         "variationKey": "blue",
@@ -936,6 +956,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -975,6 +996,7 @@
       "assignment": "yellow",
       "assignmentDetails": {
         "value": "yellow",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 15 belongs to the range of traffic assigned to \"yellow\".",
         "variationKey": "yellow",
@@ -1026,6 +1048,7 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 16 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1077,6 +1100,7 @@
       "assignment": "control",
       "assignmentDetails": {
         "value": "control",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 17 belongs to the range of traffic assigned to \"control\".",
         "variationKey": "control",
@@ -1128,6 +1152,7 @@
       "assignment": "default",
       "assignmentDetails": {
         "value": "default",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -1167,6 +1192,7 @@
       "assignment": "red",
       "assignmentDetails": {
         "value": "red",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"experiment\" and 19 belongs to the range of traffic assigned to \"red\".",
         "variationKey": "red",

--- a/ufc/tests/test-case-null-operator-flag.json
+++ b/ufc/tests/test-case-null-operator-flag.json
@@ -12,6 +12,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -49,6 +50,7 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -85,6 +87,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",
@@ -121,6 +124,7 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"not-null-operator\".",
         "variationKey": "new",
@@ -157,6 +161,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"null-operator\".",
         "variationKey": "old",

--- a/ufc/tests/test-case-numeric-flag.json
+++ b/ufc/tests/test-case-numeric-flag.json
@@ -12,6 +12,7 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -35,6 +36,7 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",
@@ -57,6 +59,7 @@
       "assignment": 3.1415926,
       "assignmentDetails": {
         "value": 3.1415926,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"pi\" defined in allocation \"rollout\".",
         "variationKey": "pi",

--- a/ufc/tests/test-case-numeric-one-of.json
+++ b/ufc/tests/test-case-numeric-one-of.json
@@ -11,6 +11,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -54,6 +55,7 @@
       "assignment": 0,
       "assignmentDetails": {
         "value": 0,
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -88,6 +90,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -131,6 +134,7 @@
       "assignment": 3,
       "assignmentDetails": {
         "value": 3,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"3-for-not-2\".",
         "variationKey": "3",
@@ -174,6 +178,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -217,6 +222,7 @@
       "assignment": 1,
       "assignmentDetails": {
         "value": 1,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"1-for-1\".",
         "variationKey": "1",
@@ -260,6 +266,7 @@
       "assignment": 2,
       "assignmentDetails": {
         "value": 2,
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"2-for-123456789\".",
         "variationKey": "2",

--- a/ufc/tests/test-case-regex-flag.json
+++ b/ufc/tests/test-case-regex-flag.json
@@ -12,6 +12,7 @@
       "assignment": "partial-example",
       "assignmentDetails": {
         "value": "partial-example",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"partial-example\".",
         "variationKey": "partial-example",
@@ -49,6 +50,7 @@
       "assignment": "test",
       "assignmentDetails": {
         "value": "test",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"test\".",
         "variationKey": "test",
@@ -85,6 +87,7 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -115,6 +118,7 @@
       "assignment": "none",
       "assignmentDetails": {
         "value": "none",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,

--- a/ufc/tests/test-case-semver-flag.json
+++ b/ufc/tests/test-case-semver-flag.json
@@ -12,6 +12,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -60,6 +61,7 @@
       "assignment": "old",
       "assignmentDetails": {
         "value": "old",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"old-versions\".",
         "variationKey": "old",
@@ -101,6 +103,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -148,6 +151,7 @@
       "assignment": "unknown",
       "assignmentDetails": {
         "value": "unknown",
+        "environmentName": "Test",
         "flagEvaluationCode": "DEFAULT_ALLOCATION_NULL",
         "flagEvaluationDescription": "No allocations matched. Falling back to \"Default Allocation\", serving NULL",
         "variationKey": null,
@@ -182,6 +186,7 @@
       "assignment": "new",
       "assignmentDetails": {
         "value": "new",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"new-versions\".",
         "variationKey": "new",
@@ -223,6 +228,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"current-versions\".",
         "variationKey": "current",

--- a/ufc/tests/test-case-start-and-end-date-flag.json
+++ b/ufc/tests/test-case-start-and-end-date-flag.json
@@ -12,6 +12,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -46,6 +47,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",
@@ -79,6 +81,7 @@
       "assignment": "current",
       "assignmentDetails": {
         "value": "current",
+        "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
         "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"current\" defined in allocation \"current-versions\".",
         "variationKey": "current",

--- a/ufc/tests/test-flag-that-does-not-exist.json
+++ b/ufc/tests/test-flag-that-does-not-exist.json
@@ -12,6 +12,7 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
+        "environmentName": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -31,6 +32,7 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
+        "environmentName": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,
@@ -49,6 +51,7 @@
       "assignment": 0.0,
       "assignmentDetails": {
         "value": 0.0,
+        "environmentName": "Test",
         "flagEvaluationCode": "FLAG_UNRECOGNIZED_OR_DISABLED",
         "flagEvaluationDescription": "Unrecognized or disabled flag: flag-that-does-not-exist",
         "variationKey": null,


### PR DESCRIPTION
Re-applies `environmentName` (without `allocation.name`) after reverting both `environmentName + allocation.name` in https://github.com/Eppo-exp/sdk-test-data/pull/41