### PR TITLE
fix: add missing totalShards

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -23,7 +23,8 @@
                 ],
                 "doLog": true
             }
-        ]
+        ],
+        "totalShards": 10000
       },
       "non_bandit_integer_flag": {
         "key": "non_bandit_integer_flag",
@@ -44,7 +45,8 @@
                 ],
                 "doLog": true
             }
-        ]
+        ],
+        "totalShards": 10000
       },
       "banner_bandit_flag": {
         "key": "banner_bandit_flag",


### PR DESCRIPTION
`totalShards` is a required field.