### PR TITLE
Adjust and expand the no actions scenario tests

### DIFF
--- a/ufc/bandit-tests/test-case-bandit-no-actions.json
+++ b/ufc/bandit-tests/test-case-bandit-no-actions.json
@@ -1,13 +1,24 @@
 {
-    "flag": "banner_bandit_flag",
-    "defaultValue": "default",
-    "subjects": [
-      {
-        "subjectKey": "alice",
-        "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
-        "actions": [],
-        "assignment": {"variation": "default", "action": null}
-      }
-    ]
-  }
-
+  "flag": "banner_bandit_flag",
+  "defaultValue": "default",
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
+      "actions": [],
+      "assignment": {"variation": "banner_bandit", "action": null}
+    },
+    {
+      "subjectKey": "ben",
+      "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
+      "actions": [],
+      "assignment": {"variation": "control", "action": null}
+    },
+    {
+      "subjectKey": "charles",
+      "subjectAttributes": {"numericAttributes": {"age": 25}, "categoricalAttributes": {"country": "USA"}},
+      "actions": [],
+      "assignment": {"variation": "default", "action": null}
+    }
+  ]
+}


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2813 - Update shared test data for no actions scenario](https://linear.app/eppo/issue/FF-2813/update-shared-test-data-for-no-actions-scenario)
🗨️ **Slack:** ["...I think there's a problem in our JS common SDK with how we handle invoking `getBanditAction()` with an empty action set...."](https://eppo-group.slack.com/archives/C05R6BK5BB9/p1721149341928549)

There may be scenarios where an empty set of actions is passed to the bandit. Before, we decided to return the default variation without logging anything if the flag had a bandit. However, this is not desirable as some users may never see the bandit due to targeting rules.

We've decided to change the behavior, and if a variation is assigned, log and return it. If the assigned variation is a bandit, and no actions are provided, we will now return--but not log--a `null` action.