### PR TITLE
fix: preserve allocation evaluation details when ASSIGNMENT_ERROR

### DIFF
--- a/test-validation/validate-tests.spec.ts
+++ b/test-validation/validate-tests.spec.ts
@@ -24,16 +24,14 @@ describe('UFC Test Validation', () => {
     describe.each(testCase.subjects.map(({subjectKey}) => subjectKey))('with subjectKey %s', (subjectKey) => {
       const subject = testCase.subjects.find((subject) => subject.subjectKey === subjectKey)!;
 
-      if (subject.evaluationDetails.variationValue === null) {
-        it('should have `assignment` match `defaultValue` when `evaluationDetails.variationValue` is null', () => {
-          expect(subject.assignment).toEqual(testCase.defaultValue);
-        })
-      }
-
-      if (subject.evaluationDetails.variationValue !== null) {
-        it('should have `assignment` match `evaluationDetails.variationValue` when `evaluationDetails.variationValue` is not null', () => {
+      if (subject.evaluationDetails.flagEvaluationCode === "MATCH") {
+        it('should have `assignment` match `evaluationDetails.variationValue` when `evaluationDetails.flagEvaluationCode` is "MATCH"', () => {
           expect(subject.assignment).toEqual(subject.evaluationDetails.variationValue);
-        })
+        });
+      } else {
+        it('should have `assignment` match `defaultValue` when `evaluationDetails.flagEvaluationCode` is not "MATCH"', () => {
+          expect(subject.assignment).toEqual(testCase.defaultValue);
+        });
       }
     });
   })

--- a/ufc/tests/test-case-invalid-value-flag.json
+++ b/ufc/tests/test-case-invalid-value-flag.json
@@ -16,23 +16,22 @@
         "flagEvaluationDescription": "Variation (pi) is configured for type INTEGER, but is set to incompatible value (3.1415926)",
         "banditKey": null,
         "banditAction": null,
-        "variationKey": null,
-        "variationValue": null,
+        "variationKey": "pi",
+        "variationValue": 3.1415926,
         "matchedRule": null,
-        "matchedAllocation": null,
-        "unmatchedAllocations": [],
-        "unevaluatedAllocations": [
+        "matchedAllocation": {
+          "key": "invalid",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
           {
             "key": "valid",
-            "allocationEvaluationCode": "UNEVALUATED",
+            "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
-          },
-          {
-            "key": "invalid",
-            "allocationEvaluationCode": "UNEVALUATED",
-            "orderPosition": 2
           }
-        ]
+        ],
+        "unevaluatedAllocations": []
       }
     },
     {
@@ -88,23 +87,22 @@
         "flagEvaluationDescription": "Variation (pi) is configured for type INTEGER, but is set to incompatible value (3.1415926)",
         "banditKey": null,
         "banditAction": null,
-        "variationKey": null,
-        "variationValue": null,
+        "variationKey": "pi",
+        "variationValue": 3.1415926,
         "matchedRule": null,
-        "matchedAllocation": null,
-        "unmatchedAllocations": [],
-        "unevaluatedAllocations": [
+        "matchedAllocation": {
+          "key": "invalid",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
           {
             "key": "valid",
-            "allocationEvaluationCode": "UNEVALUATED",
+            "allocationEvaluationCode": "FAILING_RULE",
             "orderPosition": 1
-          },
-          {
-            "key": "invalid",
-            "allocationEvaluationCode": "UNEVALUATED",
-            "orderPosition": 2
           }
-        ]
+        ],
+        "unevaluatedAllocations": []
       }
     }
   ]


### PR DESCRIPTION
ASSIGNMENT_ERROR later in the evaluation process should not revert the previously-done evaluation and definitely should not list unmatched/matched allocations as "unevaluated."