### PR TITLE
add test case for json array variation values (FF-2903)

### DIFF
--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,8 +1,8 @@
 {
-  "createdAt": "2024-04-17T19:40:53.716Z",
   "environment": {
     "name": "Test"
   },
+  "createdAt": "2024-04-17T19:40:53.716Z",
   "flags": {
     "73fcc84c69e49e31fe16a29b2b1f803b": {
       "key": "73fcc84c69e49e31fe16a29b2b1f803b",
@@ -1128,6 +1128,77 @@
         "dHdv": {
           "key": "dHdv",
           "value": "eyAiaW50ZWdlciI6IDIsICJzdHJpbmciOiAidHdvIiwgImZsb2F0IjogMi4wIH0="
+        }
+      },
+      "allocations": [
+        {
+          "key": "NTAvNTAgc3BsaXQ=",
+          "doLog": true,
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "b25l",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ],
+                  "salt": "dHJhZmZpYy1qc29uLWZsYWc="
+                },
+                {
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 5000
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ]
+            },
+            {
+              "variationKey": "dHdv",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ],
+                  "salt": "dHJhZmZpYy1qc29uLWZsYWc="
+                },
+                {
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 10000
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "858b28fb6c4573445fbcf1568527e345": {
+      "key": "858b28fb6c4573445fbcf1568527e345",
+      "enabled": true,
+      "variationType": "JSON",
+      "totalShards": 10000,
+      "variations": {
+        "b25l": {
+          "key": "b25l",
+          "value": "W3sgImludGVnZXIiOiAxLCAic3RyaW5nIjogIm9uZSIsICJmbG9hdCI6IDEuMCB9LCB7ICJpbnRlZ2VyIjogMiwgInN0cmluZyI6ICJ0d28iLCAiZmxvYXQiOiAyLjAgfV0="
+        },
+        "dHdv": {
+          "key": "dHdv",
+          "value": "W3sgImludGVnZXIiOiAzLCAic3RyaW5nIjogInRocmVlIiwgImZsb2F0IjogMy4wIH0sIHsgImludGVnZXIiOiA0LCAic3RyaW5nIjogImZvdXIiLCAiZmxvYXQiOiA0LjAgfV0="
         }
       },
       "allocations": [

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1185,6 +1185,77 @@
         }
       ],
       "totalShards": 10000
+    },
+    "json-array-config-flag": {
+      "key": "json-array-config-flag",
+      "enabled": true,
+      "variationType": "JSON",
+      "variations": {
+        "one": {
+          "key": "one",
+          "value": "[{ \"integer\": 1, \"string\": \"one\", \"float\": 1.0 }, { \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }]"
+        },
+        "two": {
+          "key": "two",
+          "value": "[{ \"integer\": 3, \"string\": \"three\", \"float\": 3.0 }, { \"integer\": 4, \"string\": \"four\", \"float\": 4.0 }]"
+        }
+      },
+      "allocations": [
+        {
+          "key": "50/50 split",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "one",
+              "shards": [
+                {
+                  "salt": "traffic-json-flag",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 5000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "two",
+              "shards": [
+                {
+                  "salt": "traffic-json-flag",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
     }
   }
 }

--- a/ufc/tests/test-json-array-config-flag.json
+++ b/ufc/tests/test-json-array-config-flag.json
@@ -1,0 +1,147 @@
+{
+  "flag": "json-array-config-flag",
+  "variationType": "JSON",
+  "defaultValue": [],
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "email": "alice@mycompany.com",
+        "country": "US"
+      },
+      "assignment": [
+        {
+          "integer": 1,
+          "string": "one",
+          "float": 1.0
+        },
+        {
+          "integer": 2,
+          "string": "two",
+          "float": 2.0
+        }
+      ],
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"one\" defined in allocation \"50/50 split\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "one",
+        "variationValue": [
+          {
+            "integer": 1,
+            "string": "one",
+            "float": 1.0
+          },
+          {
+            "integer": 2,
+            "string": "two",
+            "float": 2.0
+          }
+        ],
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "email": "bob@example.com",
+        "country": "Canada"
+      },
+      "assignment": [
+        {
+          "integer": 3,
+          "string": "three",
+          "float": 3.0
+        },
+        {
+          "integer": 4,
+          "string": "four",
+          "float": 4.0
+        }
+      ],
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "two",
+        "variationValue": [
+          {
+            "integer": 3,
+            "string": "three",
+            "float": 3.0
+          },
+          {
+            "integer": 4,
+            "string": "four",
+            "float": 4.0
+          }
+        ],
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    },
+    {
+      "subjectKey": "charlie",
+      "subjectAttributes": {
+        "age": 50
+      },
+      "assignment": [
+        {
+          "integer": 3,
+          "string": "three",
+          "float": 3.0
+        },
+        {
+          "integer": 4,
+          "string": "four",
+          "float": 4.0
+        }
+      ],
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"two\" defined in allocation \"50/50 split\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "two",
+        "variationValue": [
+          {
+            "integer": 3,
+            "string": "three",
+            "float": 3.0
+          },
+          {
+            "integer": 4,
+            "string": "four",
+            "float": 4.0
+          }
+        ],
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Observation

Broken behavior was observed in some SDKs when users create a json variation with top-level arrays.

## Changes

* Adds a discrete test for this behavior to surface all broken SDKs and prevent regressions.
* Modeled on the existing JSON test but with array values instead of object.