### PR TITLE
fix: Bump node version in sdk-test workflow to 18.x as required by the package.

### DIFF
--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -87,10 +87,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'Eppo-exp/node-server-sdk'
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - uses: actions/cache@v2
         with:
           path: './node_modules'


### PR DESCRIPTION
[package requirement](https://github.com/Eppo-exp/node-server-sdk/blob/452239cc15280a43a40f58d8eee5d9da1ce00ba7/package.json#L59)

Previous test-run failure due to node version
![image](https://github.com/user-attachments/assets/cf46a0cb-c4fd-4236-ad03-d16e5a3df45c)

Current test run (where failure is due to downstream tests actually failing at HEAD)
![image](https://github.com/user-attachments/assets/2e76c6b3-aaeb-410a-89f6-2b4b0b8bec40)
