### PR TITLE
Only run universal unit tests when the test data changes

### DIFF
--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'ufc/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -1,11 +1,6 @@
 name: Test SDKs Locally
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'ufc/**'
-
   pull_request:
     paths:
       - 'ufc/**'

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -1,8 +1,11 @@
 name: Test SDKs Locally
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
-    branches: [ "*" ]
+    paths: 
+      ufc/**
   
   workflow_dispatch:
 

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -3,9 +3,13 @@ name: Test SDKs Locally
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'ufc/**'
+
   pull_request:
-    paths: 
-      ufc/**
+    paths:
+      - 'ufc/**'
+
   
   workflow_dispatch:
 


### PR DESCRIPTION
No need to run the SDK unit tests when other parts of the repo change.