### PR TITLE
Include format field in UFC files to indicate if obfuscated or not

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -1,6 +1,6 @@
 {
     "createdAt": "2024-04-17T19:40:53.716Z",
-    "format": "server",
+    "format": "SERVER",
     "environment": {
         "name": "Test"
     },

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -1,5 +1,6 @@
 {
     "createdAt": "2024-04-17T19:40:53.716Z",
+    "format": "server",
     "environment": {
         "name": "Test"
     },

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,5 +1,6 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
+  "format": "client",
   "environment": {
     "name": "Test"
   },

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,6 +1,6 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
-  "format": "client",
+  "format": "CLIENT",
   "environment": {
     "name": "Test"
   },

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1,5 +1,6 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
+  "format": "server",
   "environment": {
     "name": "Test"
   },

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1,6 +1,6 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
-  "format": "server",
+  "format": "SERVER",
   "environment": {
     "name": "Test"
   },


### PR DESCRIPTION
_Eppo Internal:_
🎟️ [FF-3337 - Indicate in UFC the format (e.g., obfuscated or not)](https://linear.app/eppo/issue/FF-3337/indicate-in-ufc-the-format-eg-obfuscated-or-not)
👯‍♀️ Related PR: [`eppo #10896 `](https://github.com/Eppo-exp/eppo/pull/10896)
🧪 Example Use In SDK: [`sdk-common-jdk #45`](https://github.com/Eppo-exp/sdk-common-jdk/pull/45/files#diff-94d43dd76278a8107f921a3ad51611ff78dc348d16fea70231526f6b2e96f0e3R83)

To explicitly indicate if a UFC file is obfuscated or not, we're adding a `format` field. Currently, it can be `server` (unobfuscated) or `client` (obfuscated).

