### PR TITLE
Tp/testing obfuscated

### DIFF
--- a/package-testing/testing-api/package.json
+++ b/package-testing/testing-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eppo-testing-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "UFC server for SDK integration testing",
   "main": "src/server.ts",
   "repository": "github.com/Eppo-exp/sdk-test-data",

--- a/package-testing/testing-api/src/app.ts
+++ b/package-testing/testing-api/src/app.ts
@@ -33,13 +33,20 @@ class App {
     Object.keys(scenarios).forEach((key) => {
       const ufc = fs.readFileSync(path.join(baseDir, scenarios[key].ufcPath), 'utf-8');
 
+      const obfuscatedUfcFilepath = path.join(baseDir, scenarios[key].ufcPath.replace('.json', '-obfuscated.json'));
+      console.log(obfuscatedUfcFilepath);
+
+      const obfuscatedUfc = fs.existsSync(obfuscatedUfcFilepath)
+        ? fs.readFileSync(obfuscatedUfcFilepath, 'utf-8')
+        : '{}';
+
       const banditModelFile = scenarios[key].banditModelPath;
 
       const bandits = banditModelFile ? fs.readFileSync(path.join(baseDir, banditModelFile), 'utf-8') : '';
 
       console.log('preloaded data for ' + key);
 
-      setDataFile(key, ufc, bandits);
+      setDataFile(key, ufc, obfuscatedUfc, bandits);
     });
   }
 }

--- a/package-testing/testing-api/src/app.ts
+++ b/package-testing/testing-api/src/app.ts
@@ -34,7 +34,6 @@ class App {
       const ufc = fs.readFileSync(path.join(baseDir, scenarios[key].ufcPath), 'utf-8');
 
       const obfuscatedUfcFilepath = path.join(baseDir, scenarios[key].ufcPath.replace('.json', '-obfuscated.json'));
-      console.log(obfuscatedUfcFilepath);
 
       const obfuscatedUfc = fs.existsSync(obfuscatedUfcFilepath)
         ? fs.readFileSync(obfuscatedUfcFilepath, 'utf-8')

--- a/package-testing/testing-api/src/routes.ts
+++ b/package-testing/testing-api/src/routes.ts
@@ -17,7 +17,8 @@ routes.get('/api/flag-config/v1/config', (req, res) => {
   if (data) {
     // Some SDKs use HTTP headers to optimize network bytes and sdk-side processing.
     const noneMatch = req.header('IF-NONE-MATCH');
-    if (noneMatch === data.eTag) {
+    const eTagToMatch = isObfuscatedSdk(sdk) ? data.obfuscatedETag : data.eTag;
+    if (noneMatch === eTagToMatch) {
       console.log(`Returning not modified`);
       res.setHeader('ETAG', data.eTag);
       return res.status(304).end();

--- a/package-testing/testing-api/src/routes.ts
+++ b/package-testing/testing-api/src/routes.ts
@@ -15,22 +15,23 @@ routes.get('/api/flag-config/v1/config', (req, res) => {
   const data = getDataForRequest(sdk);
 
   if (data) {
-    let filename = data.ufc;
-    // Check if it should be an obfuscated response
-    if (isObfuscatedSdk(sdk)) {
-      filename = filename.replace('.json', '-obfuscated.json');
-    }
-
     // Some SDKs use HTTP headers to optimize network bytes and sdk-side processing.
     const noneMatch = req.header('IF-NONE-MATCH');
     if (noneMatch === data.eTag) {
+      console.log(`Returning not modified`);
       res.setHeader('ETAG', data.eTag);
       return res.status(304).end();
     }
 
     res.setHeader('Content-Type', 'application/json');
     res.setHeader('ETAG', data.eTag);
-    return res.status(200).end(filename);
+
+    // Check if it should be an obfuscated response
+    if (isObfuscatedSdk(sdk)) {
+      console.log(`Returning obfuscated config`);
+      return res.status(200).end(data.obfuscatedUfc);
+    }
+    return res.status(200).end(data.ufc);
   }
 
   return res.status(404).json({ message: 'No data for specified SDK' });

--- a/package-testing/testing-api/src/routes.ts
+++ b/package-testing/testing-api/src/routes.ts
@@ -18,6 +18,7 @@ routes.get('/api/flag-config/v1/config', (req, res) => {
     // Some SDKs use HTTP headers to optimize network bytes and sdk-side processing.
     const noneMatch = req.header('IF-NONE-MATCH');
     const eTagToMatch = isObfuscatedSdk(sdk) ? data.obfuscatedETag : data.eTag;
+
     if (noneMatch === eTagToMatch) {
       console.log(`Returning not modified`);
       res.setHeader('ETAG', data.eTag);

--- a/package-testing/testing-api/src/ufc/data.ts
+++ b/package-testing/testing-api/src/ufc/data.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 
-const dataFiles: Record<string, { ufc: string; eTag: string; bandits: string }> = {};
+const dataFiles: Record<string, { ufc: string; obfuscatedUfc: string; eTag: string; bandits: string }> = {};
 const clientDataMap: Record<string, string> = {};
 
 const obfuscatedClients = ['android'];
@@ -23,10 +23,10 @@ export const getDataForRequest = (sdkName: string) => {
   return filename;
 };
 
-export const setDataFile = (label: string, ufc: string, bandits: string) => {
+export const setDataFile = (label: string, ufc: string, obfuscatedUfc: string, bandits: string) => {
   const ufcVersionString = crypto.createHash('md5').update(ufc).digest('hex');
 
-  dataFiles[label] = { ufc, eTag: ufcVersionString, bandits };
+  dataFiles[label] = { ufc, obfuscatedUfc, eTag: ufcVersionString, bandits };
 };
 
 export const updateClientDataMap = (sdkName: string, datafileLabel: string): boolean => {

--- a/package-testing/testing-api/src/ufc/data.ts
+++ b/package-testing/testing-api/src/ufc/data.ts
@@ -6,7 +6,7 @@ const clientDataMap: Record<string, string> = {};
 const obfuscatedClients = ['android'];
 
 export const isObfuscatedSdk = (sdkName: string): boolean => {
-  return sdkName in obfuscatedClients;
+  return obfuscatedClients.includes(sdkName);
 };
 
 export const getDataForRequest = (sdkName: string) => {

--- a/package-testing/testing-api/src/ufc/data.ts
+++ b/package-testing/testing-api/src/ufc/data.ts
@@ -3,6 +3,12 @@ import * as crypto from 'crypto';
 const dataFiles: Record<string, { ufc: string; eTag: string; bandits: string }> = {};
 const clientDataMap: Record<string, string> = {};
 
+const obfuscatedClients = ['android'];
+
+export const isObfuscatedSdk = (sdkName: string): boolean => {
+  return sdkName in obfuscatedClients;
+};
+
 export const getDataForRequest = (sdkName: string) => {
   // Get the scenario label for this client.
   let label = clientDataMap[sdkName];
@@ -12,7 +18,9 @@ export const getDataForRequest = (sdkName: string) => {
 
   console.log(`Returning ${label} for ${sdkName}`);
 
-  return dataFiles[label] ?? null;
+  const filename = dataFiles[label] ?? null;
+
+  return filename;
 };
 
 export const setDataFile = (label: string, ufc: string, bandits: string) => {

--- a/package-testing/testing-api/src/ufc/data.ts
+++ b/package-testing/testing-api/src/ufc/data.ts
@@ -6,7 +6,7 @@ const dataFiles: Record<
 > = {};
 const clientDataMap: Record<string, string> = {};
 
-const obfuscatedClients = ['android'];
+const obfuscatedClients = ['android', 'ios', 'javascript', 'react-native'];
 
 export const isObfuscatedSdk = (sdk: string) => obfuscatedClients.includes(sdk);
 

--- a/package-testing/testing-api/src/ufc/data.ts
+++ b/package-testing/testing-api/src/ufc/data.ts
@@ -8,7 +8,7 @@ const clientDataMap: Record<string, string> = {};
 
 const obfuscatedClients = ['android'];
 
-export const isObfuscatedSdk = obfuscatedClients.includes;
+export const isObfuscatedSdk = (sdk: string) => obfuscatedClients.includes(sdk);
 
 export const getDataForRequest = (sdkName: string) => {
   // Get the scenario label for this client.

--- a/package-testing/testing-api/src/ufc/data.ts
+++ b/package-testing/testing-api/src/ufc/data.ts
@@ -1,13 +1,14 @@
 import * as crypto from 'crypto';
 
-const dataFiles: Record<string, { ufc: string; obfuscatedUfc: string; eTag: string; bandits: string }> = {};
+const dataFiles: Record<
+  string,
+  { ufc: string; obfuscatedUfc: string; eTag: string; obfuscatedETag: string; bandits: string }
+> = {};
 const clientDataMap: Record<string, string> = {};
 
 const obfuscatedClients = ['android'];
 
-export const isObfuscatedSdk = (sdkName: string): boolean => {
-  return obfuscatedClients.includes(sdkName);
-};
+export const isObfuscatedSdk = obfuscatedClients.includes;
 
 export const getDataForRequest = (sdkName: string) => {
   // Get the scenario label for this client.
@@ -16,17 +17,16 @@ export const getDataForRequest = (sdkName: string) => {
   // If there was no label, assign the first of the data files (or null).
   label ??= Object.keys(dataFiles)[0] ?? null;
 
-  console.log(`Returning ${label} for ${sdkName}`);
+  console.log(`Returning scenario ${label} for ${sdkName}`);
 
-  const filename = dataFiles[label] ?? null;
-
-  return filename;
+  return dataFiles[label] ?? null;
 };
 
 export const setDataFile = (label: string, ufc: string, obfuscatedUfc: string, bandits: string) => {
-  const ufcVersionString = crypto.createHash('md5').update(ufc).digest('hex');
+  const eTag = crypto.createHash('md5').update(ufc).digest('hex');
+  const obfuscatedETag = crypto.createHash('md5').update(obfuscatedUfc).digest('hex');
 
-  dataFiles[label] = { ufc, obfuscatedUfc, eTag: ufcVersionString, bandits };
+  dataFiles[label] = { ufc, obfuscatedUfc, eTag, obfuscatedETag, bandits };
 };
 
 export const updateClientDataMap = (sdkName: string, datafileLabel: string): boolean => {


### PR DESCRIPTION
### Motivation and Context
Joyously, it is time to implement automated package testing for our client SDKs and in order to support them, we need to serve obfuscated flag configuration. Currently, all of the client SDKs are unable to discern whether the config received from the API is obfuscated or not (none read the `format` field on a fetch, and only the android SDK will read the `format` field from side-loaded config).

### Changes
- Simple list of client SDK names to serve the obfuscated version of the flag config.
- Separate eTags for ufc and obfuscated responses
- Empty response `{}` is served when an obfuscated UFC is not in the test-data directory for the given scenario (i.e. for the bandits scenario, an empty flag response would be sent as currently bandits are not supported on mobile, though we will need to generate and serve an obfuscated version sooner or later)
