### PR TITLE
Include a cold start bandit test case

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -335,7 +335,7 @@
                     "variationValue": "cold_start_bandit"
                 }
             ],
-            "modelVersion": null
+            "modelVersion": "cold start"
         }
     }
 }

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -335,7 +335,7 @@
                     "variationValue": "cold_start_bandit"
                 }
             ],
-            "modelVersion": "cold start"
+            "modelVersion": null
         }
     }
 }

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -227,6 +227,31 @@
                 }
             ],
             "totalShards": 10000
+        },
+        "cold_start_bandit": {
+            "key": "cold_start_bandit_flag",
+            "enabled": true,
+            "variationType": "STRING",
+            "variations": {
+                "cold_start_bandit": {
+                    "key": "cold_start_bandit",
+                    "value": "cold_start_bandit"
+                }
+            },
+            "allocations": [
+                {
+                    "key": "all-traffic",
+                    "rules": [],
+                    "splits": [
+                        {
+                            "variationKey": "cold_start_bandit",
+                            "shards": []
+                        }
+                    ],
+                    "doLog": true
+                }
+            ],
+            "totalShards": 10000
         }
     },
     "bandits": {
@@ -286,7 +311,7 @@
                     "variationValue": "banner_bandit"
                 }
             ],
-            "modelVersion": "v123"
+            "modelVersion": "123"
         },
         "car_bandit": {
             "flagVariations": [
@@ -298,7 +323,7 @@
                     "variationValue": "car_bandit"
                 }
             ],
-            "modelVersion": "v456"
+            "modelVersion": "456"
         },
         "cold_start_bandit": {
             "flagVariations": [

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -228,7 +228,7 @@
             ],
             "totalShards": 10000
         },
-        "cold_start_bandit": {
+        "cold_start_bandit_flag": {
             "key": "cold_start_bandit_flag",
             "enabled": true,
             "variationType": "STRING",

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -135,7 +135,7 @@
       "banditKey": "cold_start_bandit",
       "modelName": "falcon",
       "updatedAt": "2023-09-13T04:52:06.462Z",
-      "modelVersion": null,
+      "modelVersion": "cold start",
       "modelData": {
         "gamma": 1.0,
         "defaultActionScore": 0.0,

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -8,7 +8,7 @@
       "banditKey": "banner_bandit",
       "modelName": "falcon",
       "updatedAt": "2023-09-13T04:52:06.462Z",
-      "modelVersion": "v123",
+      "modelVersion": "123",
       "modelData": {
         "gamma": 1.0,
         "defaultActionScore": 0.0,
@@ -28,9 +28,9 @@
               {
                 "attributeKey": "loyalty_tier",
                 "valueCoefficients": {
-                   "gold": 4.5,
-                   "silver":  3.2,
-                   "bronze":  1.9
+                  "gold": 4.5,
+                  "silver":  3.2,
+                  "bronze":  1.9
                 },
                 "missingValueCoefficient": 0.0
               },
@@ -110,7 +110,7 @@
       "banditKey": "car_bandit",
       "modelName": "falcon",
       "updatedAt": "2023-09-13T04:52:06.462Z",
-      "modelVersion": "v456",
+      "modelVersion": "456",
       "modelData": {
         "gamma": 1.0,
         "defaultActionScore": 5.0,
@@ -143,5 +143,5 @@
         "coefficients": {}
       }
     }
-   }
+  }
 }

--- a/ufc/bandit-models-v1.json
+++ b/ufc/bandit-models-v1.json
@@ -135,7 +135,7 @@
       "banditKey": "cold_start_bandit",
       "modelName": "falcon",
       "updatedAt": "2023-09-13T04:52:06.462Z",
-      "modelVersion": "cold start",
+      "modelVersion": null,
       "modelData": {
         "gamma": 1.0,
         "defaultActionScore": 0.0,

--- a/ufc/bandit-tests/test-case-bandit-cold-start.json
+++ b/ufc/bandit-tests/test-case-bandit-cold-start.json
@@ -1,0 +1,81 @@
+{
+  "flag": "cold_start_bandit_flag",
+  "defaultValue": "default",
+  "subjects": [
+    {
+      "subjectKey": "alice",
+      "subjectAttributes": {
+        "numericAttributes": {},
+        "categoricalAttributes": {}
+      },
+      "actions": [
+        {
+          "actionKey": "red",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        },
+        {
+          "actionKey": "blue",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        },
+        {
+          "actionKey": "green",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        }
+      ],
+      "assignment": {"variation": "cold_start_bandit", "action": "red"}
+    },
+    {
+      "subjectKey": "bob",
+      "subjectAttributes": {
+        "numericAttributes": {},
+        "categoricalAttributes": {}
+      },
+      "actions": [
+        {
+          "actionKey": "red",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        },
+        {
+          "actionKey": "blue",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        },
+        {
+          "actionKey": "green",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        }
+      ],
+      "assignment": {"variation": "cold_start_bandit", "action": "green"}
+    },
+    {
+      "subjectKey": "chelsea",
+      "subjectAttributes": {
+        "numericAttributes": {},
+        "categoricalAttributes": {}
+      },
+      "actions": [
+        {
+          "actionKey": "red",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        },
+        {
+          "actionKey": "blue",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        },
+        {
+          "actionKey": "green",
+          "numericAttributes": {},
+          "categoricalAttributes": {}
+        }
+      ],
+      "assignment": {"variation": "cold_start_bandit", "action": "green"}
+    }
+  ]
+}

--- a/ufc/bandit-tests/test-case-bandit-cold-start.json
+++ b/ufc/bandit-tests/test-case-bandit-cold-start.json
@@ -53,7 +53,7 @@
       "assignment": {"variation": "cold_start_bandit", "action": "green"}
     },
     {
-      "subjectKey": "chelsea",
+      "subjectKey": "charles",
       "subjectAttributes": {
         "numericAttributes": {},
         "categoricalAttributes": {}
@@ -75,7 +75,7 @@
           "categoricalAttributes": {}
         }
       ],
-      "assignment": {"variation": "cold_start_bandit", "action": "green"}
+      "assignment": {"variation": "cold_start_bandit", "action": "blue"}
     }
   ]
 }


### PR DESCRIPTION
We want to test when a bandit has cold-started, e.g., no model parameters have been generated yet.

Note that the UFC is currently inconsistent with the name of the version of a cold-started bandit, with "`cold start`" used in the model parameters and `null` used in the UFC. We need to align on one to avoid errors.

The plan is to align on committing the `v` prefix and using the `"cold start"` placeholder as this is more SDK friendly.

See all passing with `cold start` as the model version: https://github.com/Eppo-exp/sdk-test-data/actions/runs/11715905905/job/32633092353?pr=71
![image](https://github.com/user-attachments/assets/d633dc7d-eabe-48fd-b464-06d467c07ccf)

Mixed Results when `null` is the model version: https://github.com/Eppo-exp/sdk-test-data/actions/runs/11715993935/job/32633330226?pr=71
![image](https://github.com/user-attachments/assets/82ea3e9f-c982-4301-8281-049554fbf9b6)

This PR updates the test data to match that plan.


