### PR TITLE
feat: SDK relay launch script options

### DIFF
--- a/package-testing/sdk-test-runner/Dockerfile
+++ b/package-testing/sdk-test-runner/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18-alpine
 WORKDIR /app
 
 COPY package.json  ./
+COPY yarn.lock  ./
 
 RUN yarn install
 

--- a/package-testing/sdk-test-runner/README.md
+++ b/package-testing/sdk-test-runner/README.md
@@ -93,7 +93,9 @@ The following components are required to use the the package test runner with a 
 
 1. An **SDK relay server**. This is a REST server running at `localhost:4000` resonding to the [Asssignment and Bandit Request API](#sdk-relay-server)
    1. OR, an **SDK relay client**. This is a client application that connects to the SDK test runner via `socket.io` and responses to [Assignment requests](#sdk-relay-client)
-2. A `build-and-run.sh` file which, given a properly configured environment, [builds the SDK Relay Server application](#build-and-runsh) **using the specified version of the SDK package**.
+2. Launch Script:
+   1. A `build-and-run-<platform>.sh` file which fully configures the environment then initiates a [build and run of the relay server application](#build-and-runsh) **using the specified version of the SDK package**. <platform> is one of `linux`, `macos`, or `windows`.
+   2. OR, a `docker-run.sh` file which builds and runs a docker container running the SDK relay app
 
 The following are key components derived from above which allow for convenient and consistent dev-ops.
 

--- a/package-testing/sdk-test-runner/README.md
+++ b/package-testing/sdk-test-runner/README.md
@@ -95,7 +95,8 @@ The following components are required to use the the package test runner with a 
    1. OR, an **SDK relay client**. This is a client application that connects to the SDK test runner via `socket.io` and responses to [Assignment requests](#sdk-relay-client)
 2. Launch Script:
    1. A `build-and-run-<platform>.sh` file which fully configures the environment then initiates a [build and run of the relay server application](#build-and-runsh) **using the specified version of the SDK package**. <platform> is one of `linux`, `macos`, or `windows`.
-   2. OR, a `docker-run.sh` file which builds and runs a docker container running the SDK relay app
+   2. OR, a `build-and-run.sh` file which can configure the environment based on the env variable, `PLATFORM` and then initiate a [build and run of the relay server application](#build-and-runsh) **using the specified version of the SDK package**.
+   3. OR, a `docker-run.sh` file which builds and runs a docker container running the SDK relay app
 
 The following are key components derived from above which allow for convenient and consistent dev-ops.
 
@@ -279,6 +280,25 @@ Example `build-and-run.sh` script
 ```shell
 
 #!/usr/bin/env bash
+
+# Configure environment per platform
+case "${PLATFORM}" in
+    "windows")
+        choco install php -v ${PHP_VERSION}
+        ;;
+    "macos")
+        brew install php@${PHP_VERSION}
+        ;;
+    "ubuntu")
+        sudo apt update
+        sudo apt install php-${PHP_VERSION}
+        ;;
+    *)
+        echo "Unsupported platform: ${PLATFORM}"
+        exit 1
+        ;;
+esac
+
 
 composer install
 

--- a/package-testing/sdk-test-runner/src/app.ts
+++ b/package-testing/sdk-test-runner/src/app.ts
@@ -138,7 +138,7 @@ export default class App {
       suites: testSuites,
     };
     const junitXml = getJunitXml(testSuiteReport);
-    fs.writeFileSync(junitFile, junitXml);
+    fs.writeFileSync('./' + junitFile, junitXml);
 
     log(green(`Test results written to ${junitFile}`));
   }

--- a/package-testing/sdk-test-runner/src/app.ts
+++ b/package-testing/sdk-test-runner/src/app.ts
@@ -138,7 +138,7 @@ export default class App {
       suites: testSuites,
     };
     const junitXml = getJunitXml(testSuiteReport);
-    fs.writeFileSync('./' + junitFile, junitXml);
+    fs.writeFileSync(junitFile, junitXml);
 
     log(green(`Test results written to ${junitFile}`));
   }

--- a/package-testing/sdk-test-runner/test-sdk.sh
+++ b/package-testing/sdk-test-runner/test-sdk.sh
@@ -70,12 +70,16 @@ export SDK_RELAY_PORT="${SDK_RELAY_PORT:-4000}"
 export EPPO_SCENARIO_FILE="${EPPO_SCENARIO_FILE:-scenarios.json}"
 export EPPO_TEST_DATA_PATH="${EPPO_TEST_DATA_PATH:-./test-data}"
 
-PLATFORM="${PLATFORM:-linux}"
-
 # Validate SDK name
 if [[ -z "$SDK_NAME" ]]; then
   exit_with_message "Missing required argument: sdkName"
 fi
+
+# Ensure platform is set
+if [[ -z "$PLATFORM" ]]; then
+  exit_with_message "PLATFORM environment variable must be set"
+fi
+export PLATFORM
 
 # Extrapolate the SDK directory name
 if [[ -z "$SDK_DIR" ]]; then

--- a/package-testing/sdk-test-runner/test-sdk.sh
+++ b/package-testing/sdk-test-runner/test-sdk.sh
@@ -136,10 +136,7 @@ case "$command" in
           ./docker-run.sh >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &
         elif [ -f ${BUILD_AND_RUN_PLATFORM} ]; then
            echo "    ... Starting SDK Relay via platform build-and-run script"
-          ./build-and-run.sh >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &
-        elif [ -f build-and-run.sh ]; then
-           echo "    ... Starting SDK Relay via host build-and-run script"
-          ./build-and-run.sh >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &
+          ./${BUILD_AND_RUN_PLATFORM} >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &
         else
           exit_with_message "SDK Relay does not have a launch script in $SDK_DIR"
         fi


### PR DESCRIPTION
## Motivation and Context
Each SDK relay requires a build process to be executed in an environment configured to do so.

## Changes overview
- Specify a platform-specific build-and-run script
- use `docker-run.sh` if available
- properly exit runner script with code