### PR TITLE
fix: rename `PLATFORM` env variable

### DIFF
--- a/package-testing/sdk-test-runner/README.md
+++ b/package-testing/sdk-test-runner/README.md
@@ -95,7 +95,7 @@ The following components are required to use the the package test runner with a 
    1. OR, an **SDK relay client**. This is a client application that connects to the SDK test runner via `socket.io` and responses to [Assignment requests](#sdk-relay-client)
 2. Launch Script:
    1. A `build-and-run-<platform>.sh` file which fully configures the environment then initiates a [build and run of the relay server application](#build-and-runsh) **using the specified version of the SDK package**. <platform> is one of `linux`, `macos`, or `windows`.
-   2. OR, a `build-and-run.sh` file which can configure the environment based on the env variable, `PLATFORM` and then initiate a [build and run of the relay server application](#build-and-runsh) **using the specified version of the SDK package**.
+   2. OR, a `build-and-run.sh` file which can configure the environment based on the env variable, `EPPO_SDK_PLATFORM` and then initiate a [build and run of the relay server application](#build-and-runsh) **using the specified version of the SDK package**.
    3. OR, a `docker-run.sh` file which builds and runs a docker container running the SDK relay app
 
 The following are key components derived from above which allow for convenient and consistent dev-ops.
@@ -282,7 +282,7 @@ Example `build-and-run.sh` script
 #!/usr/bin/env bash
 
 # Configure environment per platform
-case "${PLATFORM}" in
+case "${EPPO_SDK_PLATFORM}" in
     "windows")
         choco install php -v ${PHP_VERSION}
         ;;
@@ -294,7 +294,7 @@ case "${PLATFORM}" in
         sudo apt install php-${PHP_VERSION}
         ;;
     *)
-        echo "Unsupported platform: ${PLATFORM}"
+        echo "Unsupported platform: ${EPPO_SDK_PLATFORM}"
         exit 1
         ;;
 esac

--- a/package-testing/sdk-test-runner/test-sdk.sh
+++ b/package-testing/sdk-test-runner/test-sdk.sh
@@ -76,10 +76,10 @@ if [[ -z "$SDK_NAME" ]]; then
 fi
 
 # Ensure platform is set
-if [[ -z "$PLATFORM" ]]; then
-  exit_with_message "PLATFORM environment variable must be set"
+if [[ -z "$EPPO_SDK_PLATFORM" ]]; then
+  exit_with_message "EPPO_SDK_PLATFORM environment variable must be set"
 fi
-export PLATFORM
+export EPPO_SDK_PLATFORM
 
 # Extrapolate the SDK directory name
 if [[ -z "$SDK_DIR" ]]; then
@@ -134,7 +134,7 @@ case "$command" in
         mkdir -p ${RUNNER_DIR}/logs
         pushd ../$SDK_DIR
 
-        BUILD_AND_RUN_PLATFORM=build-and-run-${PLATFORM}.sh
+        BUILD_AND_RUN_PLATFORM=build-and-run-${EPPO_SDK_PLATFORM}.sh
         if [ -f docker-run.sh ]; then
            echo "    ... Starting SDK Relay via docker launch script"
           ./docker-run.sh >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &


### PR DESCRIPTION
Turns out that `PLATFORM` is an env variable used by dotnet.