### PR TITLE
feat: Testing cluster: `EPPO_BASE_URL` environment variable

### DIFF
--- a/package-testing/php-sdk-relay/.env.EXAMPLE
+++ b/package-testing/php-sdk-relay/.env.EXAMPLE
@@ -1,6 +1,5 @@
 # Set your appropriate values and save as `.env`
-EPPO_API_HOST=localhost
-EPPO_API_PORT=5000
+EPPO_BASE_URL=localhost:5000
 EPPO_API_KEY=A123456780
 
 SDK_RELAY_HOST=localhost

--- a/package-testing/php-sdk-relay/Dockerfile
+++ b/package-testing/php-sdk-relay/Dockerfile
@@ -22,7 +22,6 @@ COPY --chmod=755 build-and-run.sh /
 RUN composer install
 
 ENV SDK_RELAY_HOST=0.0.0.0
-ENV EPPO_API_HOST=host.docker.internal
 
 EXPOSE $SDK_RELAY_PORT
 

--- a/package-testing/php-sdk-relay/docker-run.sh
+++ b/package-testing/php-sdk-relay/docker-run.sh
@@ -13,6 +13,6 @@ docker run  -p $SDK_RELAY_PORT:$SDK_RELAY_PORT \
   -e SDK_REF \
   -e SDK_RELAY_PORT \
   --name php-relay \
-  -d -rm \
+  -d --rm \
   -t Eppo-exp/php-sdk-relay:$VERSION && \
   echo "Container running"

--- a/package-testing/php-sdk-relay/docker-run.sh
+++ b/package-testing/php-sdk-relay/docker-run.sh
@@ -13,6 +13,6 @@ docker run  -p $SDK_RELAY_PORT:$SDK_RELAY_PORT \
   -e SDK_REF \
   -e SDK_RELAY_PORT \
   --name php-relay \
-  -d \
+  -d -rm \
   -t Eppo-exp/php-sdk-relay:$VERSION && \
   echo "Container running"

--- a/package-testing/php-sdk-relay/src/Config.php
+++ b/package-testing/php-sdk-relay/src/Config.php
@@ -10,8 +10,7 @@ class Config
     public function __construct()
     {
         $this->apiKey = $_ENV["EPPO_API_KEY"] ?? "NOKEYSPECIFIED";
-        $apiHost = $_ENV["EPPO_API_HOST"] ?? "localhost";
-        $apiPort = $_ENV["EPPO_API_PORT"] ?? "5000";
-        $this->apiServer = "http://${apiHost}:${apiPort}";
+        $apiServer = $_ENV["EPPO_BASE_URL"] ?? "localhost:5000";
+        $this->apiServer = "http://${apiServer}";
     }
 }

--- a/package-testing/sdk-test-runner/README.md
+++ b/package-testing/sdk-test-runner/README.md
@@ -183,12 +183,13 @@ The test runner sends assignment and bandit action requests to the SDK Relay Ser
 
 #### Configuration
 
-| Variable Name    | Type   | Description               | Default     |
-| ---------------- | ------ | ------------------------- | ----------- |
-| `SDK_RELAY_HOST` | string | Hostname for relay server | `localhost` |
-| `SDK_RELAY_PORT` | number | Port for relay server     | 4000        |
-| `EPPO_API_HOST`  | string | Hostname for api server   | `localhost` |
-| `EPPO_API_PORT`  | number | Port for api server       | 5000        |
+| Variable Name    | Type   | Default          | Description                                                             |
+| ---------------- | ------ | ---------------- | ----------------------------------------------------------------------- |
+| `SDK_RELAY_HOST` | string | `localhost`      | Hostname for relay server                                               |
+| `SDK_RELAY_PORT` | number | 4000             | Port for relay server                                                   |
+| `EPPO_BASE_URL`  | string | `localhost:5000` | Base URL for api server, built from `EPPO_API_HOST` and `EPPO_API_PORT` |
+| `EPPO_API_HOST`  | string | `localhost`      | Hostname for api server                                                 |
+| `EPPO_API_PORT`  | number | 5000             | Port for api server                                                     |
 
 #### API
 

--- a/package-testing/sdk-test-runner/test-sdk.sh
+++ b/package-testing/sdk-test-runner/test-sdk.sh
@@ -63,6 +63,7 @@ fi
 # Allow env variables to be overwritten, then export to this shell.
 export EPPO_API_HOST="${EPPO_API_HOST:-localhost}"
 export EPPO_API_PORT="${EPPO_API_PORT:-5000}"
+export EPPO_BASE_URL="${EPPO_API_HOST}:${EPPO_API_PORT}"
 
 export SDK_RELAY_HOST="${SDK_RELAY_HOST:-localhost}"
 export SDK_RELAY_PORT="${SDK_RELAY_PORT:-4000}"
@@ -137,7 +138,9 @@ case "$command" in
         BUILD_AND_RUN_PLATFORM=build-and-run-${PLATFORM}.sh
         if [ -f docker-run.sh ]; then
            echo "    ... Starting SDK Relay via docker launch script"
-          ./docker-run.sh >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &
+
+          # Docker containers need to point at host.docker.internal instead of localhost
+          EPPO_BASE_URL=host.docker.internal:${EPPO_API_PORT} EPPO_API_HOST=host.docker.internal ./docker-run.sh >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &
         elif [ -f ${BUILD_AND_RUN_PLATFORM} ]; then
            echo "    ... Starting SDK Relay via platform build-and-run script"
           ./${BUILD_AND_RUN_PLATFORM} >> ${RUNNER_DIR}/logs/sdk.log 2>&1 &


### PR DESCRIPTION
The `EPPO_BASE_URL` environment variable is a handy combination of `EPPO_API_HOST` and `EPPO_API_PORT. It's better to use this variable in the SDK relay nodes instead of checking for the presence of a port and appending it to the host in each node. (Here, and "SDK Node" refers to an SDK relay server or client, like the [php-relay](https://github.com/Eppo-exp/sdk-test-data/tree/main/package-testing/php-sdk-relay))

Also, quick fix to the PHP docker run to remove the container after running. Makes local runs much easier.