### PR TITLE
feat: github workflows to build and push (to GCP Artifact Reg) images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,57 @@
+name: Build and push SDK Test Runner
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version string for SDK Test Runner release'
+        type: string
+        required: true
+      docker_context:
+        type: string
+        description: 'Directory where dockerfile exists'
+        required: true
+      image_name:
+        type: string
+        description: 'Docker image name'
+        required: true
+
+env:
+  VERSION: 1.1.0
+
+  PROJECT_ID: ${{ vars.SDK_TESTING_PROJECT_ID  }}
+  REGION: ${{ vars.SDK_TESTING_REGION }}
+  GAR_LOCATION: ${{ vars.SDK_TESTING_REGION }}-docker.pkg.dev/${{ vars.SDK_TESTING_PROJECT_ID  }}/sdk-testing
+
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+
+      # Set up gCloud
+      - id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: "Use gcloud CLI"
+        run: "gcloud info"
+
+      # Allow docker access to the GAR
+      - name: "Docker auth"
+        run: |-
+          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      # Build and push
+      - name: Build and export
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: ${{ inputs.docker_context }}
+          tags: ${{ env.GAR_LOCATION }}/${{ inputs.image_name }}:latest,${{ env.GAR_LOCATION }}/${{ inputs.image_name }}:${{ env.VERSION }}

--- a/.github/workflows/release-sdk-test-runner.yml
+++ b/.github/workflows/release-sdk-test-runner.yml
@@ -1,0 +1,22 @@
+name: Build and push SDK Test Runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version string for SDK Test Runner release'
+        required: true
+        default: '1.0.0'
+
+  push:
+    paths:
+      .github/workflows/release-sdk-test-runner.yml
+
+jobs:
+  build-and-upload:
+    uses: ./.github/workflows/build-and-push.yml
+    with:
+      version: ${{ inputs.version }}
+      docker_context: ./package-testing/sdk-test-runner
+      image_name: sdk-test-runner
+    secrets: inherit

--- a/.github/workflows/release-sdk-testing-api.yml
+++ b/.github/workflows/release-sdk-testing-api.yml
@@ -1,0 +1,22 @@
+name: Build and push Testing API
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version string for SDK Testing API release'
+        required: true
+        default: '1.0.0'
+
+  push:
+    paths:
+      .github/workflows/release-sdk-testing-api.yml
+
+jobs:
+  build-and-upload:
+    uses: ./.github/workflows/build-and-push.yml
+    with:
+      version: ${{ inputs.version }}
+      docker_context: ./package-testing/testing-api
+      image_name: testing-api
+    secrets: inherit

--- a/.github/workflows/validate-test-data.yml
+++ b/.github/workflows/validate-test-data.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/validate-test-data.yml'
       - 'ufc/tests/**'
   push:
     branches:


### PR DESCRIPTION
towards FF-3104
## Motivation and Context
We want to use prebuilt docker images to make rolling out a test cluster faster

## Overview of changes
- Secrets and Variables are set on this repository (via admin UI)
- common workflow to build and push an image to the GAR
- workflows for each of the images we want to build.