### PR TITLE
feat: run eppo-multiplatform tests for in-flight changes

### DIFF
--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -25,13 +25,16 @@ jobs:
           # - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           # - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           # - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
-          - { repo: "eppo-multiplatform", workflow: "python.yml", ref: "main" }
+          - { repo: "eppo-multiplatform", workflow: "python.yml", ref: "tp/testDataBranch" }
+          - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "tp/testDataBranch" }
+          - { repo: "eppo-multiplatform", workflow: "ruby.yml", ref: "tp/testDataBranch" }
+          - { repo: "eppo-multiplatform", workflow: "msrv.yml", ref: "tp/testDataBranch" }
           # - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
     steps:
     - name: Display workflow details
       shell: bash
       run: |
-        echo "Testing eppo-exp/${{ matrix.sdk.repo }}"
+        echo "Testing eppo-exp/${{ matrix.sdk.repo }}/${{ matrix.sdk.workflow }}"
     - name: Run remote workflow
       uses: convictional/trigger-workflow-and-wait@v1.6.1
       with:

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -25,9 +25,9 @@ jobs:
           # - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           # - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           # - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
-          - { repo: "eppo-multiplatform", workflow: "python.yml", ref: "tp/testDataBranch" }
+          # - { repo: "eppo-multiplatform", workflow: "python.yml", ref: "tp/testDataBranch" }
           - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "tp/testDataBranch" }
-          - { repo: "eppo-multiplatform", workflow: "ruby.yml", ref: "tp/testDataBranch" }
+          # - { repo: "eppo-multiplatform", workflow: "ruby.yml", ref: "tp/testDataBranch" }
           # - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
     steps:
     - name: Display workflow details

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -17,18 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         sdk:
-          # - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
-          # - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
-          # - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
-          # - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
-          # - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          # - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          # - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          # - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
-          # - { repo: "eppo-multiplatform", workflow: "python.yml", ref: "tp/testDataBranch" }
-          - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "tp/testDataBranch" }
-          # - { repo: "eppo-multiplatform", workflow: "ruby.yml", ref: "tp/testDataBranch" }
-          # - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
+          - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
+          - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
+          - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
+          - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
+          - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
+          - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "main" }
+          - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
     steps:
     - name: Display workflow details
       shell: bash

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -1,4 +1,6 @@
 name: Test SDKs Remotely
+# Triggers testing workflows in all SDK repositories except eppo-multiplatform
+# For eppo-multiplatform, Depndabot does the job of the remote-testing by opening a PR against the repo to update test data.
 
 on:
   push:
@@ -15,18 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
+      matrix: 
         sdk:
-          # - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
-          # - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
-          # - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
-          # - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
-          # - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          # - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          # - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          # - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
-          - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "tp/testDataBranch" }
-          # - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
+          - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
+          - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
+          - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
+          - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
+          - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
+          - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
     steps:
     - name: Display workflow details
       shell: bash
@@ -41,7 +42,6 @@ jobs:
         ref: ${{ matrix.sdk.ref }}
         github_token: ${{ secrets.AUTH_TOKEN }}
         wait_interval: 10
-        client_payload: '{"test_data_branch": "tp/fail/test"}'
         propagate_failure: true
         trigger_workflow: true
         wait_workflow: true

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -28,7 +28,6 @@ jobs:
           - { repo: "eppo-multiplatform", workflow: "python.yml", ref: "tp/testDataBranch" }
           - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "tp/testDataBranch" }
           - { repo: "eppo-multiplatform", workflow: "ruby.yml", ref: "tp/testDataBranch" }
-          - { repo: "eppo-multiplatform", workflow: "msrv.yml", ref: "tp/testDataBranch" }
           # - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
     steps:
     - name: Display workflow details

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         sdk:
-          - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
-          - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
-          - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
-          - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
-          - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
-          - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "main" }
-          - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
+          # - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
+          # - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
+          # - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
+          # - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
+          # - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          # - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          # - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          # - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
+          - { repo: "eppo-multiplatform", workflow: "ci.yml", ref: "tp/testDataBranch" }
+          # - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
     steps:
     - name: Display workflow details
       shell: bash
@@ -41,6 +41,7 @@ jobs:
         ref: ${{ matrix.sdk.ref }}
         github_token: ${{ secrets.AUTH_TOKEN }}
         wait_interval: 10
+        client_payload: '{"test_data_branch": "tp/fail/test"}'
         propagate_failure: true
         trigger_workflow: true
         wait_workflow: true

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'ufc/**'
+      - '.github/workflows/test-sdks-remote.yml'
   workflow_dispatch:
 
 jobs:
@@ -16,16 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         sdk:
-          - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
-          - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
-          - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
-          - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
-          - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
-          - { repo: "python-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
-          - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
+          # - { repo: "android-sdk", workflow: "test.yaml", ref: "main" }
+          # - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
+          # - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
+          # - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
+          # - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          # - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          # - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
+          # - { repo: "php-sdk", workflow: "run-tests.yml", ref: "main" }
+          - { repo: "eppo-multiplatform", workflow: "python.yml", ref: "main" }
+          # - { repo: "react-native-sdk", workflow: "ci.yml", ref: "main" }
     steps:
     - name: Display workflow details
       shell: bash

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Run test action"
-        uses: 'Eppo-exp/eppo-multiplatform/.github/actions/action-test-sdk@tp/testDataBranch'
+        uses: 'Eppo-exp/eppo-multiplatform/.github/actions/action-test-python@tp/testDataBranch'
         with:
           test_data_branch: ${{ github.head_ref || github.ref_name }}
           sdk_branch: main

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -40,7 +40,7 @@ jobs:
   test-multiplatform-sdk:
     uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@main'
     with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      test_data_branch: tp/fail/test
       sdk_branch: main
 
   test-php-sdk:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -4,71 +4,65 @@ on:
   pull_request:
     paths:
       - 'ufc/**'
-  push:
-    paths:
-      - .github/workflows/test-sdks.yml
-      - 'ufc/**'
-
-  workflow_dispatch:
 
 jobs:
   
-  # test-java-sdk:
-  #   uses: Eppo-exp/java-server-sdk/.github/workflows/lint-test-sdk.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
-  
-  # test-android-sdk:
-  #   uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
-      
-  # test-node-server-sdk:
-  #   uses: Eppo-exp/node-server-sdk/.github/workflows/lint-test-sdk.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
-  
-  # test-node-client-sdk:
-  #   uses: Eppo-exp/js-client-sdk/.github/workflows/lint-test-sdk.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
-
-  # test-react-native-sdk:
-  #   uses: Eppo-exp/react-native-sdk/.github/workflows/ci.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
-
-  test-multiplatform-sdk:
-    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@tp/testDataBranch'
+  test-java-sdk:
+    uses: Eppo-exp/java-server-sdk/.github/workflows/lint-test-sdk.yml@main
     with:
       test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: tp/testDataBranch
+      sdk_branch: main
+  
+  test-android-sdk:
+    uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
+      
+  test-node-server-sdk:
+    uses: Eppo-exp/node-server-sdk/.github/workflows/lint-test-sdk.yml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
+  
+  test-node-client-sdk:
+    uses: Eppo-exp/js-client-sdk/.github/workflows/lint-test-sdk.yml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
 
-  # test-php-sdk:
-  #   uses: Eppo-exp/php-sdk/.github/workflows/run-tests.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
+  test-react-native-sdk:
+    uses: Eppo-exp/react-native-sdk/.github/workflows/ci.yml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
 
-  # test-ios-sdk:
-  #   uses: Eppo-exp/eppo-ios-sdk/.github/workflows/unit-tests.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
+  test-multiplatform-sdk:
+    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@main'
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
 
-  # test-golang-sdk:
-  #   uses: Eppo-exp/golang-sdk/.github/workflows/test.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
+  test-php-sdk:
+    uses: Eppo-exp/php-sdk/.github/workflows/run-tests.yml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
 
-  # test-dotnet-sdk:
-  #   uses: Eppo-exp/dot-net-server-sdk/.github/workflows/run-tests.yml@main
-  #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
-  #     sdk_branch: main
+  test-ios-sdk:
+    uses: Eppo-exp/eppo-ios-sdk/.github/workflows/unit-tests.yml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
+
+  test-golang-sdk:
+    uses: Eppo-exp/golang-sdk/.github/workflows/test.yml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
+
+  test-dotnet-sdk:
+    uses: Eppo-exp/dot-net-server-sdk/.github/workflows/run-tests.yml@main
+    with:
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -40,7 +40,7 @@ jobs:
       sdk_branch: main
 
   test-multiplatform-sdk:
-    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@main'
+    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@tp/testDataBranch'
     with:
       test_data_branch: tp/fail/test
       sdk_branch: main

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -40,9 +40,9 @@ jobs:
       sdk_branch: main
 
   test-multiplatform-sdk:
-    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@tp/testDataBranch'
+    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@main'
     with:
-      test_data_branch: tp/fail/test
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
       sdk_branch: main
 
   test-php-sdk:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -42,23 +42,8 @@ jobs:
   #   with:
   #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
-  
-  test-python-sdk:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Run test action"
-        uses: 'Eppo-exp/eppo-multiplatform/.github/actions/action-test-python@tp/testDataBranch'
-        with:
-          test_data_branch: ${{ github.head_ref || github.ref_name }}
-          sdk_branch: tp/testDataBranch
 
-  test-ruby-sdk:
-    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ruby.yml@tp/testDataBranch'
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: tp/testDataBranch
-
-  test-rust-sdk:
+  test-multiplatform-sdk:
     uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@tp/testDataBranch'
     with:
       test_data_branch: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -15,31 +15,31 @@ jobs:
   # test-java-sdk:
   #   uses: Eppo-exp/java-server-sdk/.github/workflows/lint-test-sdk.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
   
   # test-android-sdk:
   #   uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
       
   # test-node-server-sdk:
   #   uses: Eppo-exp/node-server-sdk/.github/workflows/lint-test-sdk.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
   
   # test-node-client-sdk:
   #   uses: Eppo-exp/js-client-sdk/.github/workflows/lint-test-sdk.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
 
   # test-react-native-sdk:
   #   uses: Eppo-exp/react-native-sdk/.github/workflows/ci.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
   
   test-python-sdk:
@@ -48,29 +48,41 @@ jobs:
       - name: "Run test action"
         uses: 'Eppo-exp/eppo-multiplatform/.github/actions/action-test-python@tp/testDataBranch'
         with:
-          test_data_branch: ${{ github.head_ref || github.ref_name }}
+          test_data_branch: ${{ github.ref }}
           sdk_branch: tp/testDataBranch
-  
+
+  test-ruby-sdk:
+    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ruby.yml@tp/testDataBranch'
+    with:
+      test_data_branch: ${{ github.ref }}
+      sdk_branch: tp/testDataBranch
+
+  test-rust-sdk:
+    uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@tp/testDataBranch'
+    with:
+      test_data_branch: ${{ github.ref }}
+      sdk_branch: tp/testDataBranch
+
   # test-php-sdk:
   #   uses: Eppo-exp/php-sdk/.github/workflows/run-tests.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
 
   # test-ios-sdk:
   #   uses: Eppo-exp/eppo-ios-sdk/.github/workflows/unit-tests.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
 
   # test-golang-sdk:
   #   uses: Eppo-exp/golang-sdk/.github/workflows/test.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main
 
   # test-dotnet-sdk:
   #   uses: Eppo-exp/dot-net-server-sdk/.github/workflows/run-tests.yml@main
   #   with:
-  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     test_data_branch: ${{ github.ref }}
   #     sdk_branch: main

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - .github/workflows/test-sdks.yml
+      - 'ufc/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'ufc/**'
 
+  workflow_dispatch:
+
 jobs:
   
   test-java-sdk:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -4,69 +4,73 @@ on:
   pull_request:
     paths:
       - 'ufc/**'
+  push:
+    paths:
+      - .github/workflows/test-sdks.yml
+
   workflow_dispatch:
 
 jobs:
   
-  test-java-sdk:
-    uses: Eppo-exp/java-server-sdk/.github/workflows/lint-test-sdk.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-java-sdk:
+  #   uses: Eppo-exp/java-server-sdk/.github/workflows/lint-test-sdk.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
   
-  test-android-sdk:
-    uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-android-sdk:
+  #   uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
       
-  test-node-server-sdk:
-    uses: Eppo-exp/node-server-sdk/.github/workflows/lint-test-sdk.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-node-server-sdk:
+  #   uses: Eppo-exp/node-server-sdk/.github/workflows/lint-test-sdk.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
   
-  test-node-client-sdk:
-    uses: Eppo-exp/js-client-sdk/.github/workflows/lint-test-sdk.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-node-client-sdk:
+  #   uses: Eppo-exp/js-client-sdk/.github/workflows/lint-test-sdk.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
 
-  test-react-native-sdk:
-    uses: Eppo-exp/react-native-sdk/.github/workflows/ci.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-react-native-sdk:
+  #   uses: Eppo-exp/react-native-sdk/.github/workflows/ci.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
   
   test-python-sdk:
     runs-on: ubuntu-latest
     steps:
       - name: "Run test action"
-        uses: 'Eppo-exp/python-sdk/.github/actions/action-test@main'
+        uses: 'Eppo-exp/eppo-multiplatform/.github/actions/action-test-sdk@tp/testDataBranch'
         with:
           test_data_branch: ${{ github.head_ref || github.ref_name }}
           sdk_branch: main
   
-  test-php-sdk:
-    uses: Eppo-exp/php-sdk/.github/workflows/run-tests.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-php-sdk:
+  #   uses: Eppo-exp/php-sdk/.github/workflows/run-tests.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
 
-  test-ios-sdk:
-    uses: Eppo-exp/eppo-ios-sdk/.github/workflows/unit-tests.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-ios-sdk:
+  #   uses: Eppo-exp/eppo-ios-sdk/.github/workflows/unit-tests.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
 
-  test-golang-sdk:
-    uses: Eppo-exp/golang-sdk/.github/workflows/test.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-golang-sdk:
+  #   uses: Eppo-exp/golang-sdk/.github/workflows/test.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main
 
-  test-dotnet-sdk:
-    uses: Eppo-exp/dot-net-server-sdk/.github/workflows/run-tests.yml@main
-    with:
-      test_data_branch: ${{ github.head_ref || github.ref_name }}
-      sdk_branch: main
+  # test-dotnet-sdk:
+  #   uses: Eppo-exp/dot-net-server-sdk/.github/workflows/run-tests.yml@main
+  #   with:
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
+  #     sdk_branch: main

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -16,31 +16,31 @@ jobs:
   # test-java-sdk:
   #   uses: Eppo-exp/java-server-sdk/.github/workflows/lint-test-sdk.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
   
   # test-android-sdk:
   #   uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
       
   # test-node-server-sdk:
   #   uses: Eppo-exp/node-server-sdk/.github/workflows/lint-test-sdk.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
   
   # test-node-client-sdk:
   #   uses: Eppo-exp/js-client-sdk/.github/workflows/lint-test-sdk.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
 
   # test-react-native-sdk:
   #   uses: Eppo-exp/react-native-sdk/.github/workflows/ci.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
   
   test-python-sdk:
@@ -49,41 +49,41 @@ jobs:
       - name: "Run test action"
         uses: 'Eppo-exp/eppo-multiplatform/.github/actions/action-test-python@tp/testDataBranch'
         with:
-          test_data_branch: ${{ github.ref }}
+          test_data_branch: ${{ github.head_ref || github.ref_name }}
           sdk_branch: tp/testDataBranch
 
   test-ruby-sdk:
     uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ruby.yml@tp/testDataBranch'
     with:
-      test_data_branch: ${{ github.ref }}
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
       sdk_branch: tp/testDataBranch
 
   test-rust-sdk:
     uses: 'Eppo-exp/eppo-multiplatform/.github/workflows/ci.yml@tp/testDataBranch'
     with:
-      test_data_branch: ${{ github.ref }}
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
       sdk_branch: tp/testDataBranch
 
   # test-php-sdk:
   #   uses: Eppo-exp/php-sdk/.github/workflows/run-tests.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
 
   # test-ios-sdk:
   #   uses: Eppo-exp/eppo-ios-sdk/.github/workflows/unit-tests.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
 
   # test-golang-sdk:
   #   uses: Eppo-exp/golang-sdk/.github/workflows/test.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main
 
   # test-dotnet-sdk:
   #   uses: Eppo-exp/dot-net-server-sdk/.github/workflows/run-tests.yml@main
   #   with:
-  #     test_data_branch: ${{ github.ref }}
+  #     test_data_branch: ${{ github.head_ref || github.ref_name }}
   #     sdk_branch: main

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -49,7 +49,7 @@ jobs:
         uses: 'Eppo-exp/eppo-multiplatform/.github/actions/action-test-python@tp/testDataBranch'
         with:
           test_data_branch: ${{ github.head_ref || github.ref_name }}
-          sdk_branch: main
+          sdk_branch: tp/testDataBranch
   
   # test-php-sdk:
   #   uses: Eppo-exp/php-sdk/.github/workflows/run-tests.yml@main

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -9,7 +9,7 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": 3,
+      "assignment": 5,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -52,7 +52,7 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": 3,
+      "assignment": 15,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -94,7 +94,7 @@
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": 2,
+      "assignment": 66,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -126,7 +126,7 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": 3,
+      "assignment": 56,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -166,7 +166,7 @@
     {
       "subjectKey": "1",
       "subjectAttributes": {},
-      "assignment": 2,
+      "assignment": 99,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -194,7 +194,7 @@
     {
       "subjectKey": "2",
       "subjectAttributes": {},
-      "assignment": 2,
+      "assignment": 99,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",

--- a/ufc/tests/test-case-integer-flag.json
+++ b/ufc/tests/test-case-integer-flag.json
@@ -9,7 +9,7 @@
         "email": "alice@mycompany.com",
         "country": "US"
       },
-      "assignment": 5,
+      "assignment": 3,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -52,7 +52,7 @@
         "email": "bob@example.com",
         "country": "Canada"
       },
-      "assignment": 15,
+      "assignment": 3,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -94,7 +94,7 @@
       "subjectAttributes": {
         "age": 50
       },
-      "assignment": 66,
+      "assignment": 2,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -126,7 +126,7 @@
         "country": "Mexico",
         "age": 25
       },
-      "assignment": 56,
+      "assignment": 3,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -166,7 +166,7 @@
     {
       "subjectKey": "1",
       "subjectAttributes": {},
-      "assignment": 99,
+      "assignment": 2,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
@@ -194,7 +194,7 @@
     {
       "subjectKey": "2",
       "subjectAttributes": {},
-      "assignment": 99,
+      "assignment": 2,
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",


### PR DESCRIPTION
🎟️ towards FF-3085

👯‍♂️ **Related PRs**
- [eppo-multiplatform](https://github.com/Eppo-exp/eppo-multiplatform/pull/73)
- #57
- #58
- #59

### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
- Refactor testing for multiplatform SDK

External to this Change
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.