### PR TITLE
feat: local and remote trigger Java common SDK testing

### DIFF
--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -20,6 +20,7 @@ jobs:
           - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
           - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
           - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
+          - { repo: "sdk-common-jvm", workflow: "lint-test-sdk.yml", ref: "tp/apibranch" }
           - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -20,7 +20,7 @@ jobs:
           - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
           - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
           - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
-          - { repo: "sdk-common-jdk", workflow: "lint-test-sdk.yml", ref: "tp/apibranch" }
+          - { repo: "sdk-common-jdk", workflow: "lint-test-sdk.yml", ref: "main" }
           - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }

--- a/.github/workflows/test-sdks-remote.yml
+++ b/.github/workflows/test-sdks-remote.yml
@@ -20,7 +20,7 @@ jobs:
           - { repo: "dot-net-server-sdk", workflow: "run-tests.yml", ref: "main" }
           - { repo: "eppo-ios-sdk", workflow: "unit-tests.yml", ref: "main" }
           - { repo: "golang-sdk", workflow: "test.yml", ref: "main" }
-          - { repo: "sdk-common-jvm", workflow: "lint-test-sdk.yml", ref: "tp/apibranch" }
+          - { repo: "sdk-common-jdk", workflow: "lint-test-sdk.yml", ref: "tp/apibranch" }
           - { repo: "java-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           - { repo: "js-client-sdk", workflow: "lint-test-sdk.yml", ref: "main" }
           - { repo: "node-server-sdk", workflow: "lint-test-sdk.yml", ref: "main" }

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -13,7 +13,13 @@ jobs:
     with:
       test_data_branch: ${{ github.head_ref || github.ref_name }}
       sdk_branch: main
-  
+    
+  test-java-common-sdk:
+    uses: Eppo-exp/sdk-common-jdk/.github/workflows/lint-test-sdk.yml@tp/apibranch
+    with:
+      test_data_branch: tp/fail/test
+      sdk_branch: tp/apibranch
+    
   test-android-sdk:
     uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
     with:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -13,13 +13,13 @@ jobs:
     with:
       test_data_branch: ${{ github.head_ref || github.ref_name }}
       sdk_branch: main
-    
+
   test-java-common-sdk:
     uses: Eppo-exp/sdk-common-jdk/.github/workflows/lint-test-sdk.yml@tp/apibranch
     with:
       test_data_branch: tp/fail/test
       sdk_branch: tp/apibranch
-    
+
   test-android-sdk:
     uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main
     with:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -15,10 +15,10 @@ jobs:
       sdk_branch: main
 
   test-java-common-sdk:
-    uses: Eppo-exp/sdk-common-jdk/.github/workflows/lint-test-sdk.yml@tp/apibranch
+    uses: Eppo-exp/sdk-common-jdk/.github/workflows/lint-test-sdk.yml@main
     with:
-      test_data_branch: tp/fail/test
-      sdk_branch: tp/apibranch
+      test_data_branch: ${{ github.head_ref || github.ref_name }}
+      sdk_branch: main
 
   test-android-sdk:
     uses: Eppo-exp/android-sdk/.github/workflows/test.yaml@main


### PR DESCRIPTION
🎟️ towards FF-3085
Ticket FF-3085

👯‍♂️ **Related PRs**
- [sdk-common-jvm](https://github.com/Eppo-exp/sdk-common-jdk/pull/72)
- #57
- #58
- #59 

### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
- add java-common testing to the group!

Repos are green!

External to this Change
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.