### PR TITLE
fix: bandit attributes, logs, and baseUrl in dotnet SDK relay

### DIFF
--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/AssignmentLogger.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/AssignmentLogger.cs
@@ -4,15 +4,22 @@ using eppo_sdk.logger;
 
 internal class AssignmentLogger : IAssignmentLogger
 {
+    public static AssignmentLogger Instance = new();
+
+    public Queue<AssignmentLogData> AssignmentLogs = new();
+    public Queue<BanditLogEvent> BanditLogs = new();
+
     public void LogAssignment(AssignmentLogData assignmentLogData)
     {
         Console.WriteLine("Assignment Log");
         Console.WriteLine(assignmentLogData);
+        AssignmentLogs.Enqueue(assignmentLogData);
     }
 
     public void LogBanditAction(BanditLogEvent banditLogEvent)
     {
         Console.WriteLine("Bandit Action Log");
         Console.WriteLine(banditLogEvent);
+        BanditLogs.Enqueue(banditLogEvent);
     }
 }

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/AssignmentController.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/AssignmentController.cs
@@ -29,22 +29,22 @@ public class AssignmentController : JsonControllerBase
         switch (data.AssignmentType)
         {
             case "STRING":
-                return JsonResult(eppoClient.GetStringAssignment(data.Flag, data.SubjectKey, convertedAttributes, defaultValue.ToString()!));
+                return JsonTestResponse(eppoClient.GetStringAssignment(data.Flag, data.SubjectKey, convertedAttributes, defaultValue.ToString()!));
 
             case "INTEGER":
                 var intResults = eppoClient.GetIntegerAssignment(data.Flag, data.SubjectKey, convertedAttributes, Convert.ToInt64(defaultValue.ToString()));
-                return JsonResult(intResults);
+                return JsonTestResponse(intResults);
 
             case "BOOLEAN":
-                return JsonResult(eppoClient.GetBooleanAssignment(data.Flag, data.SubjectKey, convertedAttributes, Convert.ToBoolean(defaultValue.ToString())));
+                return JsonTestResponse(eppoClient.GetBooleanAssignment(data.Flag, data.SubjectKey, convertedAttributes, Convert.ToBoolean(defaultValue.ToString())));
 
             case "NUMERIC":
-                return JsonResult(eppoClient.GetNumericAssignment(data.Flag, data.SubjectKey, convertedAttributes, Convert.ToDouble(defaultValue.ToString())));
+                return JsonTestResponse(eppoClient.GetNumericAssignment(data.Flag, data.SubjectKey, convertedAttributes, Convert.ToDouble(defaultValue.ToString())));
 
             case "JSON":
                 var jString = defaultValue.ToString();
                 var defaultJson = JObject.Parse(jString);
-                return JsonResult(eppoClient.GetJsonAssignment(data.Flag, data.SubjectKey, convertedAttributes, defaultJson));
+                return JsonTestResponse(eppoClient.GetJsonAssignment(data.Flag, data.SubjectKey, convertedAttributes, defaultJson));
         }
 
         return JsonError("Invalid Assignment Type " + data.AssignmentType);

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/BanditController.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/BanditController.cs
@@ -33,6 +33,6 @@ public class BanditController : JsonControllerBase
                                                 subject,
                                                 actions,
                                                 defaultVal);
-        return JsonResult(result);
+        return JsonTestResponse(result);
     }
 }

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/JsonControllerBase.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/JsonControllerBase.cs
@@ -3,10 +3,13 @@ using Microsoft.AspNetCore.Mvc;
 using EppoSDKRelay.DTO;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
+using eppo_sdk.dto;
+using eppo_sdk.dto.bandit;
 
 namespace EppoSDKRelay.controllers;
 
-public class JsonControllerBase : ControllerBase {
+public class JsonControllerBase : ControllerBase
+{
 
     protected static readonly JsonSerializerOptions SerializeOptions = new()
     {
@@ -14,7 +17,26 @@ public class JsonControllerBase : ControllerBase {
         WriteIndented = true
     };
 
-    protected static ActionResult<string> JsonResult(object result)
+    protected static ActionResult<string> JsonTestResponse(object result)
+    {
+        // System.Text.Json does not play nicely with Newtonsoft types
+        // Since "Objects" implement IEnumerable, System.Text will try to encode
+        // the json object as an array. :(
+        if (result is JObject)
+        {
+            result = ((JObject)result).ToObject<Dictionary<string, object>>();
+        }
+
+        var response = new TestResponse
+        {
+            Result = result,
+            AssignmentLog = DequeueAll<AssignmentLogData>(AssignmentLogger.Instance.AssignmentLogs),
+            BanditLog =  DequeueAll<BanditLogEvent>(AssignmentLogger.Instance.BanditLogs),
+        };
+        return JsonSerializer.Serialize(response, SerializeOptions);
+    }
+
+    protected static ActionResult<string> JsonObjectResponse(object result)
     {
         // System.Text.Json does not play nicely with Newtonsoft types
         // Since "Objects" implement IEnumerable, System.Text will try to encode
@@ -22,12 +44,7 @@ public class JsonControllerBase : ControllerBase {
         if (result is JObject) {
             result = ((JObject)result).ToObject<Dictionary<string, object>>();
         }
-
-        var response = new TestResponse
-        {
-            Result = result
-        };
-        return JsonSerializer.Serialize(response, SerializeOptions);
+        return JsonSerializer.Serialize(result, SerializeOptions);
     }
     
     protected static ActionResult<string> JsonError(String error)
@@ -37,5 +54,21 @@ public class JsonControllerBase : ControllerBase {
             Error = error
         }, SerializeOptions);
     }
-    
+
+
+    public static List<object> DequeueAll<T>(Queue<T> queue)
+    {
+        List<object> items = [];
+
+        while (queue.Count > 0)
+        {
+            var item = queue.Dequeue();
+            if (item != null)
+            {
+                items.Add(item);
+            }
+        }
+
+        return items;
+    }
 }

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/JsonControllerBase.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/Controllers/JsonControllerBase.cs
@@ -30,23 +30,12 @@ public class JsonControllerBase : ControllerBase
         var response = new TestResponse
         {
             Result = result,
-            AssignmentLog = DequeueAll<AssignmentLogData>(AssignmentLogger.Instance.AssignmentLogs),
-            BanditLog =  DequeueAll<BanditLogEvent>(AssignmentLogger.Instance.BanditLogs),
+            AssignmentLog = DequeueAllForResponse<AssignmentLogData>(AssignmentLogger.Instance.AssignmentLogs),
+            BanditLog =  DequeueAllForResponse<BanditLogEvent>(AssignmentLogger.Instance.BanditLogs),
         };
         return JsonSerializer.Serialize(response, SerializeOptions);
     }
 
-    protected static ActionResult<string> JsonObjectResponse(object result)
-    {
-        // System.Text.Json does not play nicely with Newtonsoft types
-        // Since "Objects" implement IEnumerable, System.Text will try to encode
-        // the json object as an array. :(
-        if (result is JObject) {
-            result = ((JObject)result).ToObject<Dictionary<string, object>>();
-        }
-        return JsonSerializer.Serialize(result, SerializeOptions);
-    }
-    
     protected static ActionResult<string> JsonError(String error)
     {
         return JsonSerializer.Serialize(new TestResponse
@@ -55,8 +44,7 @@ public class JsonControllerBase : ControllerBase
         }, SerializeOptions);
     }
 
-
-    public static List<object> DequeueAll<T>(Queue<T> queue)
+    public static List<object> DequeueAllForResponse<T>(Queue<T> queue)
     {
         List<object> items = [];
 

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/DTO/AttributeSet.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/DTO/AttributeSet.cs
@@ -4,14 +4,8 @@ using System.Text.Json;
 
 public class AttributeSet
 {
-    public Dictionary<string, object?> NumericAttributes { get; set; }
-    public Dictionary<string, object?> CategoricalAttributes { get; set; }
-
-    public Dictionary<string, object?> AttributeDictionary
-    {
-        get => new Dictionary<string, object?>[] { NumericAttributes, CategoricalAttributes }.SelectMany(dict => dict)
-                         .ToDictionary(pair => pair.Key, pair => pair.Value);
-    }
+    public required Dictionary<string, object?> NumericAttributes { get; set; }
+    public required Dictionary<string, object?> CategoricalAttributes { get; set; }
 
     public Dictionary<string, string?> CategoricalAttributesAsStrings
     {
@@ -23,6 +17,5 @@ public class AttributeSet
     public Dictionary<string, object?> NumericAttributesAsNumbers => NumericAttributes
                 .Where(kvp =>
                     (kvp.Value is JsonElement jsonElement) && jsonElement.ValueKind == JsonValueKind.Number)
-                .ToDictionary(kvp => kvp.Key, static kvp => (object?)((JsonElement)kvp.Value).GetDouble());
-
+                .ToDictionary(kvp => kvp.Key, static kvp => kvp.Value == null ? null : (object?)((JsonElement)kvp.Value).GetDouble());
 }

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/DTO/BanditActionRequest.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/DTO/BanditActionRequest.cs
@@ -21,6 +21,6 @@ public class BanditActionRequest
     public IDictionary<string, ContextAttributes> GetActionContextDict()
     {
         return Actions.ToDictionary(action => action.ActionKey,
-                                    action => ContextAttributes.FromDict(action.ActionKey, Values.ConvertJsonValuesToPrimitives(action.AttributeDictionary)));
+                                    action => ContextAttributes.FromNullableAttributes(action.ActionKey, Values.ConvertJsonValuesToPrimitives(action.CategoricalAttributes), Values.ConvertJsonValuesToPrimitives(action.NumericAttributes)));
     }
 }

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/EppoSDKRelay.csproj
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/EppoSDKRelay.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eppo.Sdk" Version="3.4.0" />
+    <PackageReference Include="Eppo.Sdk" Version="3.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/Program.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/Program.cs
@@ -14,5 +14,8 @@ public static class Program
             {
                 builder.UseStartup<Startup>();
                 builder.UseUrls("http://" + host + ":" + port);
+
+                // Listen on the docker hostname as well
+                builder.UseUrls("http://host.docker.internal:" + port);
             });
 }

--- a/package-testing/dotnet-sdk-relay/EppoSDKRelay/Startup.cs
+++ b/package-testing/dotnet-sdk-relay/EppoSDKRelay/Startup.cs
@@ -5,19 +5,17 @@ namespace EppoSDKRelay;
 
 public class Startup
 {
-    static readonly String apiHost = Environment.GetEnvironmentVariable("EPPO_API_HOST") ?? "localhost";
-    static readonly String apiPort = Environment.GetEnvironmentVariable("EPPO_API_PORT") ?? "5000";
+    static readonly String eppoBaseUrl = Environment.GetEnvironmentVariable("EPPO_BASE_URL") ?? "http://localhost:5000/api";
     static readonly String apiToken = Environment.GetEnvironmentVariable("EPPO_API_TOKEN") ?? "NO_TOKEN";
 
 
     public static void InitEppoClient()
     {
-        var url =  "http://" + apiHost + ":" + apiPort;
-        Console.WriteLine("Initializating SDK pointed at" + url);
+        Console.WriteLine("Initializating SDK pointed at" + eppoBaseUrl);
 
-        var eppoClientConfig = new EppoClientConfig(apiToken, new AssignmentLogger())
+        var eppoClientConfig = new EppoClientConfig(apiToken, AssignmentLogger.Instance)
         {
-            BaseUrl = url
+            BaseUrl = eppoBaseUrl
         };
 
         EppoClient.Init(eppoClientConfig);
@@ -45,7 +43,6 @@ public class Startup
             app.UseDeveloperExceptionPage();
 
             app.UseSwagger();
-            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "My REST Server v1"));
         }
 
         app.UseHttpsRedirection();


### PR DESCRIPTION
🎟️ Fixes: FF-3635

## Motivation and Context

Some SDKs allow passing <String, Object> for numeric attributes (for subjects and actions when evaluating bandits). This was recently added to the `ContextAttributes` helper class in the dotnet SDK.

When debugging, having the full bandit and assignment logs returned to the test runner is critical


## Changes
- use BaseUrl instead of host/port in relay runner to conform to convention
- Return bandit and assignment logs in the test responses
- Handle the Categorical and Numeric attributes separately, using the new `ContextAttributes` API

## How has this been tested

- Prior to this change, the incorrect handling of attributes (to get around the lack of support for dynamic typing) the test for **Imogene** fails (see attached). After this change, the attributes are correctly sorted and converted (as can be seen in the bandit logs returned from the relay). Test suite passes fully with this change.
- 
![image](https://github.com/user-attachments/assets/a7857925-d213-43f4-a06b-dcf18a9bacfb)

Passing Test suite
![image](https://github.com/user-attachments/assets/31b448f7-4805-490d-8de0-87798cfc86f4)

