### PR TITLE
Add script for testing rubygem published package in alpine and debian.

### DIFF
--- a/package-testing/ruby-sdk-relay/README.md
+++ b/package-testing/ruby-sdk-relay/README.md
@@ -1,0 +1,18 @@
+## Ruby SDK Testing
+
+This directory contains scripts for testing the Ruby SDK in various environments.
+
+### Test Ruby Gems Installation
+
+Verifies that the Ruby SDK can be installed from RubyGems in a variety of environments.
+
+The `test-rubygems-install.sh` script builds Docker images for Alpine and Debian and runs the test script inside each container.
+
+You should see output like the following if the tests pass:
+
+```
+Successfully installed eppo-server-sdk-3.3.0-aarch64-linux
+1 gem installed
+Installed version: 3.3.0
+✅ Installation successful in debian environment
+```

--- a/package-testing/ruby-sdk-relay/published-versions/Dockerfile.rubygems.alpine
+++ b/package-testing/ruby-sdk-relay/published-versions/Dockerfile.rubygems.alpine
@@ -1,0 +1,18 @@
+FROM ruby:3.3-alpine
+
+# Install bash
+RUN apk add --no-cache bash
+
+# Create a test user
+RUN adduser -D testuser
+
+# Copy script and set permissions while still root
+COPY test-gem.sh /home/testuser/
+RUN chmod +x /home/testuser/test-gem.sh && \
+    chown testuser:testuser /home/testuser/test-gem.sh
+
+# Switch to test user
+USER testuser
+WORKDIR /home/testuser
+
+CMD ["bash", "/home/testuser/test-gem.sh"]

--- a/package-testing/ruby-sdk-relay/published-versions/Dockerfile.rubygems.debian
+++ b/package-testing/ruby-sdk-relay/published-versions/Dockerfile.rubygems.debian
@@ -1,0 +1,15 @@
+FROM ruby:3.3-slim-bullseye
+
+# Create a test user
+RUN useradd -m testuser
+
+# Copy script and set permissions while still root
+COPY test-gem.sh /home/testuser/
+RUN chmod +x /home/testuser/test-gem.sh && \
+    chown testuser:testuser /home/testuser/test-gem.sh
+
+# Switch to test user
+USER testuser
+WORKDIR /home/testuser
+
+CMD ["bash", "/home/testuser/test-gem.sh"]

--- a/package-testing/ruby-sdk-relay/published-versions/test-gem.sh
+++ b/package-testing/ruby-sdk-relay/published-versions/test-gem.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Install the gem and verify it works
+gem install eppo-server-sdk
+ruby -r eppo_client -e 'puts "Installed version: #{EppoClient::VERSION}"' 

--- a/package-testing/ruby-sdk-relay/test-rubygems-install.sh
+++ b/package-testing/ruby-sdk-relay/test-rubygems-install.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Default environment if none specified
+ENV=${1:-"all"}
+
+# Constants
+DOCKERFILE_FORMAT="Dockerfile.rubygems"
+DOCKER_TAG_PREFIX="rubygems-test"
+TEST_DIRECTORY="published-versions"
+
+# Ensure we're in the correct directory
+cd "$(dirname "$0")"
+
+# Ensure test script exists
+if [ ! -f "$TEST_DIRECTORY/test-gem.sh" ]; then
+    echo "Error: $TEST_DIRECTORY/test-gem.sh not found"
+    exit 1
+fi
+
+# Function to test in specific environment
+test_environment() {
+    local env=$1
+    echo "Testing installation in $env environment..."
+    
+    # Build from the published-versions directory where both Dockerfile and test-gem.sh are located
+    docker build -t "$DOCKER_TAG_PREFIX-$env" -f "$TEST_DIRECTORY/$DOCKERFILE_FORMAT.$env" "$TEST_DIRECTORY"
+    docker run --rm "$DOCKER_TAG_PREFIX-$env"
+    
+    local result=$?
+    if [ $result -eq 0 ]; then
+        echo "✅ Installation successful in $env environment"
+    else
+        echo "❌ Installation failed in $env environment"
+    fi
+    return $result
+}
+
+# Run tests based on environment parameter
+case $ENV in
+    "alpine")
+        test_environment "alpine"
+        ;;
+    "debian")
+        test_environment "debian"
+        ;;
+    "all")
+        failed=0
+        test_environment "alpine" || failed=1
+        test_environment "debian" || failed=1
+        exit $failed
+        ;;
+    *)
+        echo "Unsupported environment: $ENV"
+        echo "Supported environments: alpine, debian, all"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
We had a bug report from a customer about a failure to install inside an alpine and debian environments. The Ruby gems need to be prebuild in the multiplatform repository so this was not expected.

A script is needed to verify that we have coverage in these environments and bug reports can be reproduced.

```
➜  ruby-sdk-relay git:(lr/ff-3655/ruby-relay) ✗ ./test-rubygems-install.sh
Testing installation in alpine environment...
[+] Building 0.5s (11/11) FINISHED                                                                                                                     docker:desktop-linux
 => [internal] load build definition from Dockerfile.rubygems.alpine                                                                                                   0.0s
 => => transferring dockerfile: 455B                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/ruby:3.3-alpine                                                                                                     0.4s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [1/6] FROM docker.io/library/ruby:3.3-alpine@sha256:caeab43b356463e63f87af54a03de1ae4687b36da708e6d37025c557ade450f8                                               0.0s
 => [internal] load build context                                                                                                                                      0.0s
 => => transferring context: 231B                                                                                                                                      0.0s
 => CACHED [2/6] RUN apk add --no-cache bash                                                                                                                           0.0s
 => CACHED [3/6] RUN adduser -D testuser                                                                                                                               0.0s
 => CACHED [4/6] COPY test-gem.sh /home/testuser/                                                                                                                      0.0s
 => CACHED [5/6] RUN chmod +x /home/testuser/test-gem.sh &&     chown testuser:testuser /home/testuser/test-gem.sh                                                     0.0s
 => CACHED [6/6] WORKDIR /home/testuser                                                                                                                                0.0s
 => exporting to image                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                0.0s
 => => writing image sha256:395b687c891eb96e1b0e89d3804076a081e6b73e0a6c95f17cb6752e20b53b3d                                                                           0.0s
 => => naming to docker.io/library/rubygems-test-alpine                                                                                                                0.0s

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview
Successfully installed eppo-server-sdk-3.3.0-aarch64-linux-musl
1 gem installed
Installed version: 3.3.0
✅ Installation successful in alpine environment
Testing installation in debian environment...
[+] Building 0.2s (10/10) FINISHED                                                                                                                     docker:desktop-linux
 => [internal] load build definition from Dockerfile.rubygems.debian                                                                                                   0.0s
 => => transferring dockerfile: 418B                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/ruby:3.3-slim-bullseye                                                                                              0.2s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [1/5] FROM docker.io/library/ruby:3.3-slim-bullseye@sha256:c194f29a6188e77e878eb2cfa35e8f3d51936bc36c86878865a07c7a9a85f7bf                                        0.0s
 => [internal] load build context                                                                                                                                      0.0s
 => => transferring context: 70B                                                                                                                                       0.0s
 => CACHED [2/5] RUN useradd -m testuser                                                                                                                               0.0s
 => CACHED [3/5] COPY test-gem.sh /home/testuser/                                                                                                                      0.0s
 => CACHED [4/5] RUN chmod +x /home/testuser/test-gem.sh &&     chown testuser:testuser /home/testuser/test-gem.sh                                                     0.0s
 => CACHED [5/5] WORKDIR /home/testuser                                                                                                                                0.0s
 => exporting to image                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                0.0s
 => => writing image sha256:11841bba29e5563fcfc16ec289a750123479bc7c0c8aa18e5366ff4cb6c8e002                                                                           0.0s
 => => naming to docker.io/library/rubygems-test-debian                                                                                                                0.0s

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview
Successfully installed eppo-server-sdk-3.3.0-aarch64-linux
1 gem installed
Installed version: 3.3.0
✅ Installation successful in debian environment
```