### PR TITLE
feat: map multiple bandits to a flag

### DIFF
--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -73,6 +73,10 @@
                 "banner_bandit": {
                     "key": "banner_bandit",
                     "value": "banner_bandit"
+                },
+                "car_bandit": {
+                    "key": "car_bandit",
+                    "value": "car_bandit"
                 }
             },
             "allocations": [

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -87,7 +87,7 @@
                             "conditions": [
                                 {
                                     "attribute": "id",
-                                    "operator": "EQUALS",
+                                    "operator": "MATCHES",
                                     "value": "override"
                                 }
                             ]

--- a/ufc/bandit-flags-v1.json
+++ b/ufc/bandit-flags-v1.json
@@ -77,6 +77,38 @@
             },
             "allocations": [
                 {
+                    "key": "testing",
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "attribute": "id",
+                                    "operator": "EQUALS",
+                                    "value": "override"
+                                }
+                            ]
+                        }
+                    ],
+                    "splits": [
+                      {
+                        "variationKey": "car_bandit",
+                        "shards": [
+                            {
+                                "salt": "traffic-car-bandit-flag-all",
+                                "ranges": [
+                                    {
+                                        "start": 0,
+                                        "end": 10000
+                                    }   
+                                ]
+                            }
+                        ]
+                      }
+          
+                    ],
+                    "doLog": false
+                },         
+                {
                     "key": "analysis",
                     "splits": [
                         {
@@ -275,6 +307,12 @@
                 "flagKey": "car_bandit_flag",
                 "variationKey": "car_bandit",
                 "variationValue": "car_bandit"
+            },
+            {
+                "key": "car_bandit",
+                "flagKey": "banner_bandit_flag",
+                "variationKey": "car_bandit",
+                "variationValue": "car_bandit"
             }
         ],
         "cold_start_bandit": [
@@ -321,10 +359,17 @@
                     "allocationKey": "all-traffic",
                     "variationKey": "car_bandit",
                     "variationValue": "car_bandit"
+                },
+                {
+                    "key": "car_bandit",
+                    "flagKey": "banner_bandit_flag",
+                    "allocationKey": "testing",
+                    "variationKey": "car_bandit",
+                    "variationValue": "car_bandit"
                 }
             ],
             "modelVersion": "456"
-        },
+          },
         "cold_start_bandit": {
             "flagVariations": [
                 {

--- a/ufc/bandit-tests/test-case-banner-bandit.json
+++ b/ufc/bandit-tests/test-case-banner-bandit.json
@@ -261,6 +261,32 @@
           }
         ],
         "assignment": {"variation": "banner_bandit", "action": "nike"}
+      },
+      {
+        "subjectKey": "override",
+        "subjectAttributes": {
+            "numericAttributes": {},
+            "categoricalAttributes": {}
+          },
+
+        "actions": [
+            {
+              "actionKey": "nike",
+              "numericAttributes": {},
+              "categoricalAttributes": {}
+            },
+            {
+              "actionKey": "adidas",
+              "numericAttributes": {},
+              "categoricalAttributes": {}
+            },
+            {
+              "actionKey": "reebok",
+              "numericAttributes": {},
+              "categoricalAttributes": {}
+            }
+          ],
+          "assignment": {"variation": "car_bandit", "action": "adidas"}
       }
     ]
   }


### PR DESCRIPTION
## Motivation and Context
In order to support precomputed bandits we need to compute all bandits related to a flag in some situations. This data change adds an allocation to banner_bandit_flag which maps to car_bandit