### PR TITLE
fix: context attribute keys in precomputed config wire

### DIFF
--- a/configuration-wire/precomputed-v1-deobfuscated.json
+++ b/configuration-wire/precomputed-v1-deobfuscated.json
@@ -3,13 +3,13 @@
     "precomputed": {
         "subjectKey": "test-subject-key",
         "subjectAttributes": {
-            "categorical": {
+            "categoricalAttributes": {
                 "platform": "ios",
                 "language": "en-US",
                 "hasPushEnabled": false,
                 "buildNumber": 42
             },
-            "numeric": {
+            "numericAttributes": {
                 "lastLoginDays": 3,
                 "lifetimeValue": 543.21
             }

--- a/configuration-wire/precomputed-v1.json
+++ b/configuration-wire/precomputed-v1.json
@@ -3,13 +3,13 @@
   "precomputed": {
     "subjectKey": "test-subject-key",
     "subjectAttributes": {
-      "categorical": {
+      "categoricalAttributes": {
         "platform": "ios",
         "language": "en-US",
         "hasPushEnabled": false,
         "buildNumber": 42
       },
-      "numeric": {
+      "numericAttributes": {
         "lastLoginDays": 3,
         "lifetimeValue": 543.21
       }


### PR DESCRIPTION
I believe these should match

https://github.com/Eppo-exp/js-sdk-common/blob/b1048a32587a809bed351af07185592c9f774150/src/types.ts#L5-L8

```typescript
export type ContextAttributes = {
  numericAttributes: Attributes;
  categoricalAttributes: Attributes;
};
```