### PR TITLE
show json serialized diff of test and expectations

### DIFF
--- a/package-testing/sdk-test-runner/package.json
+++ b/package-testing/sdk-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk-test-runner",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Test runner for SDK package testing",
   "main": "src/app.ts",
   "repository": "https://github.com/Eppo-exp/sdk-test-data",

--- a/package-testing/sdk-test-runner/src/app.ts
+++ b/package-testing/sdk-test-runner/src/app.ts
@@ -276,14 +276,16 @@ export default class App {
                 message: result.error,
               });
 
-              logIndent(1, red('fail') + ` ${testCaseLabel}: ${result.result} != ${subject.assignment}`);
+              logIndent(1, red('fail') + ` ${testCaseLabel}: ${result.error}`);
             } else if (!App.isResultCorrect(result, subject)) {
               testCaseResult.failures ??= [];
               testCaseResult.failures.push({
-                message: `Value ${result.result} did not match expected ${subject.assignment}`,
+                message: `Value ${JSON.stringify(result.result)} did not match expected ${JSON.stringify(subject.assignment)}`,
               });
 
-              logIndent(1, red('fail') + ` ${testCaseLabel}: ${result.result} != ${subject.assignment}`);
+              logIndent(1, red('fail') + ` ${testCaseLabel}:\n` + 
+                `  Expected: ${JSON.stringify(subject.assignment, null, 2)}\n` +
+                `  Received: ${JSON.stringify(result.result, null, 2)}`);
             } else {
               testCaseResult.assertions = 1;
 


### PR DESCRIPTION
nested tests failures are not currently helpful:

```
  fail banner_bandit_flag_uk_only[charlie]: [object Object] != [object Object]
  fail banner_bandit_flag_uk_only[debra]: [object Object] != [object Object]
  fail banner_bandit_flag_uk_only[erica]: [object Object] != [object Object]
  fail banner_bandit_flag_uk_only[frenkie]: [object Object] != [object Object]
  fail banner_bandit_flag_uk_only[gerard]: [object Object] != [object Object]
```

## testing

deployed this branch and re-ran failing branch:

```
  fail banner_bandit_flag[frenkie]:
  Expected: ***
  "variation": "banner_bandit",
  "action": "puma"
***
  Received: ***
  "action": null,
  "variation": "default"
***
  fail banner_bandit_flag[gerard]:
  Expected: ***
  "variation": "banner_bandit",
  "action": "nike"
***
  Received: ***
  "action": null,
  "variation": "default"
***
  fail banner_bandit_flag[henry]:
  Expected: ***
  "variation": "banner_bandit",
  "action": "adidas"
***
  Received: ***
  "action": null,
  "variation": "default"
***
```