### PR TITLE
Include test case for special characters

### DIFF
--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1186,6 +1186,104 @@
           ]
         }
       ]
+    },
+    "eab426e60c686e18da04981a4d53c837": {
+      "allocations": [
+        {
+          "doLog": true,
+          "key": "YWxsb2NhdGlvbi10ZXN0",
+          "splits": [
+            {
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "end": 2500,
+                      "start": 0
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ],
+              "variationKey": "ZGU="
+            },
+            {
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "end": 5000,
+                      "start": 2500
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ],
+              "variationKey": "cnU="
+            },
+            {
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "end": 7500,
+                      "start": 5000
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ],
+              "variationKey": "emg="
+            },
+            {
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "end": 10000,
+                      "start": 7500
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ],
+              "variationKey": "ZW1vamk="
+            }
+          ]
+        },
+        {
+          "doLog": false,
+          "key": "YWxsb2NhdGlvbi1kZWZhdWx0",
+          "splits": [
+            {
+              "shards": [],
+              "variationKey": "ZGU="
+            }
+          ]
+        }
+      ],
+      "enabled": true,
+      "key": "eab426e60c686e18da04981a4d53c837",
+      "totalShards": 10000,
+      "variationType": "JSON",
+      "variations": {
+        "ZGU=": {
+          "key": "ZGU=",
+          "value": "eyJhIjogImvDvG1tZXJ0IiwgImIiOiAic2Now7ZuIn0="
+        },
+        "ZW1vamk=": {
+          "key": "ZW1vamk=",
+          "value": "eyJhIjogIvCfpJciLCAiYiI6ICLwn4y4In0="
+        },
+        "cnU=": {
+          "key": "cnU=",
+          "value": "eyJhIjogItC30LDQsdC+0YLQuNGC0YHRjyIsICJiIjogItC60YDQsNGB0LjQstGL0LkifQ=="
+        },
+        "emg=": {
+          "key": "emg=",
+          "value": "eyJhIjogIueFp+mhviIsICJiIjogIua8guS6riJ9"
+        }
+      }
     }
   }
 }

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1219,7 +1219,7 @@
                   "salt": "c3BsaXQtanNvbi1mbGFn"
                 }
               ],
-              "variationKey": "cnU="
+              "variationKey": "dWE="
             },
             {
               "shards": [
@@ -1275,9 +1275,9 @@
           "key": "ZW1vamk=",
           "value": "eyJhIjogIvCfpJciLCAiYiI6ICLwn4y4In0="
         },
-        "cnU=": {
-          "key": "cnU=",
-          "value": "eyJhIjogItC30LDQsdC+0YLQuNGC0YHRjyIsICJiIjogItC60YDQsNGB0LjQstGL0LkifQ=="
+        "dWE=": {
+          "key": "dWE=",
+          "value": "eyJhIjogItC/0ZbQutC70YPQstCw0YLQuNGB0Y8iLCAiYiI6ICLQu9GO0LHQvtCyIn0="
         },
         "emg=": {
           "key": "emg=",

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1196,9 +1196,9 @@
           "key": "de",
           "value": "{\"a\": \"kümmert\", \"b\": \"schön\"}"
         },
-        "ru": {
-          "key": "ru",
-          "value": "{\"a\": \"заботится\", \"b\": \"красивый\"}"
+        "ua": {
+          "key": "ua",
+          "value": "{\"a\": \"піклуватися\", \"b\": \"любов\"}"
         },
         "zh": {
           "key": "zh",
@@ -1229,7 +1229,7 @@
               ]
             },
             {
-              "variationKey": "ru",
+              "variationKey": "ua",
               "shards": [
                 {
                   "salt": "split-json-flag",

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1186,6 +1186,104 @@
         }
       ],
       "totalShards": 10000
+    },
+    "special-characters": {
+      "key": "special-characters",
+      "enabled": true,
+      "variationType": "JSON",
+      "variations": {
+        "de": {
+          "key": "de",
+          "value": "{\"a\": \"kümmert\", \"b\": \"schön\"}"
+        },
+        "ru": {
+          "key": "ru",
+          "value": "{\"a\": \"заботится\", \"b\": \"красивый\"}"
+        },
+        "zh": {
+          "key": "zh",
+          "value": "{\"a\": \"照顾\", \"b\": \"漂亮\"}"
+        },
+        "emoji": {
+          "key": "emoji",
+          "value": "{\"a\": \"🤗\", \"b\": \"🌸\"}"
+        }
+      },
+      "totalShards": 10000,
+      "allocations": [
+        {
+          "key": "allocation-test",
+          "splits": [
+            {
+              "variationKey": "de",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 2500
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "ru",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 2500,
+                      "end": 5000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "zh",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 7500
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "emoji",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 7500,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-default",
+          "splits": [
+            {
+              "variationKey": "de",
+              "shards": []
+            }
+          ],
+          "doLog": false
+        }
+      ]
     }
   }
 }

--- a/ufc/tests/test-special-characters.json
+++ b/ufc/tests/test-special-characters.json
@@ -41,8 +41,8 @@
       "subjectKey": "ben",
       "subjectAttributes": {},
       "assignment": {
-        "a": "заботится",
-        "b": "красивый"
+        "a": "піклуватися",
+        "b": "любов"
       },
       "evaluationDetails": {
         "environmentName": "Test",
@@ -50,10 +50,10 @@
         "flagEvaluationDescription": "ben belongs to the range of traffic assigned to \"ru\" defined in allocation \"allocation-test\".",
         "banditKey": null,
         "banditAction": null,
-        "variationKey": "ru",
+        "variationKey": "ua",
         "variationValue": {
-          "a": "заботится",
-          "b": "красивый"
+          "a": "піклуватися",
+          "b": "любов"
         },
         "matchedRule": null,
         "matchedAllocation": {

--- a/ufc/tests/test-special-characters.json
+++ b/ufc/tests/test-special-characters.json
@@ -13,7 +13,7 @@
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
-        "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"de\" defined in allocation \"allocation-test\".",
+        "flagEvaluationDescription": "ash belongs to the range of traffic assigned to \"de\" defined in allocation \"allocation-test\".",
         "banditKey": null,
         "banditAction": null,
         "variationKey": "de",
@@ -41,7 +41,7 @@
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
-        "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"ru\" defined in allocation \"allocation-test\".",
+        "flagEvaluationDescription": "ben belongs to the range of traffic assigned to \"ru\" defined in allocation \"allocation-test\".",
         "banditKey": null,
         "banditAction": null,
         "variationKey": "ru",
@@ -69,7 +69,7 @@
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
-        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"zh\" defined in allocation \"allocation-test\".",
+        "flagEvaluationDescription": "cameron belongs to the range of traffic assigned to \"zh\" defined in allocation \"allocation-test\".",
         "banditKey": null,
         "banditAction": null,
         "variationKey": "zh",
@@ -97,7 +97,7 @@
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
-        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"emoji\" defined in allocation \"allocation-test\".",
+        "flagEvaluationDescription": "darryl belongs to the range of traffic assigned to \"emoji\" defined in allocation \"allocation-test\".",
         "banditKey": null,
         "banditAction": null,
         "variationKey": "emoji",

--- a/ufc/tests/test-special-characters.json
+++ b/ufc/tests/test-special-characters.json
@@ -47,7 +47,7 @@
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
-        "flagEvaluationDescription": "ben belongs to the range of traffic assigned to \"ru\" defined in allocation \"allocation-test\".",
+        "flagEvaluationDescription": "ben belongs to the range of traffic assigned to \"ua\" defined in allocation \"allocation-test\".",
         "banditKey": null,
         "banditAction": null,
         "variationKey": "ua",

--- a/ufc/tests/test-special-characters.json
+++ b/ufc/tests/test-special-characters.json
@@ -28,7 +28,13 @@
           "orderPosition": 1
         },
         "unmatchedAllocations": [],
-        "unevaluatedAllocations": []
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-default",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
       }
     },
     {
@@ -56,7 +62,13 @@
           "orderPosition": 1
         },
         "unmatchedAllocations": [],
-        "unevaluatedAllocations": []
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-default",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
       }
     },
     {
@@ -84,7 +96,13 @@
           "orderPosition": 1
         },
         "unmatchedAllocations": [],
-        "unevaluatedAllocations": []
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-default",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
       }
     },
     {
@@ -112,7 +130,13 @@
           "orderPosition": 1
         },
         "unmatchedAllocations": [],
-        "unevaluatedAllocations": []
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-default",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
       }
     }
   ]

--- a/ufc/tests/test-special-characters.json
+++ b/ufc/tests/test-special-characters.json
@@ -1,0 +1,119 @@
+{
+  "flag": "special-characters",
+  "variationType": "JSON",
+  "defaultValue": {},
+  "subjects": [
+    {
+      "subjectKey": "ash",
+      "subjectAttributes": {},
+      "assignment": {
+        "a": "kümmert",
+        "b": "schön"
+      },
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "alice belongs to the range of traffic assigned to \"de\" defined in allocation \"allocation-test\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "de",
+        "variationValue": {
+          "a": "kümmert",
+          "b": "schön"
+        },
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "allocation-test",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    },
+    {
+      "subjectKey": "ben",
+      "subjectAttributes": {},
+      "assignment": {
+        "a": "заботится",
+        "b": "красивый"
+      },
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "bob belongs to the range of traffic assigned to \"ru\" defined in allocation \"allocation-test\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "ru",
+        "variationValue": {
+          "a": "заботится",
+          "b": "красивый"
+        },
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "allocation-test",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    },
+    {
+      "subjectKey": "cameron",
+      "subjectAttributes": {},
+      "assignment": {
+        "a": "照顾",
+        "b": "漂亮"
+      },
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"zh\" defined in allocation \"allocation-test\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "zh",
+        "variationValue": {
+          "a": "照顾",
+          "b": "漂亮"
+        },
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "allocation-test",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    },
+    {
+      "subjectKey": "darryl",
+      "subjectAttributes": {},
+      "assignment": {
+        "a": "🤗",
+        "b": "🌸"
+      },
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "charlie belongs to the range of traffic assigned to \"emoji\" defined in allocation \"allocation-test\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "emoji",
+        "variationValue": {
+          "a": "🤗",
+          "b": "🌸"
+        },
+        "matchedRule": null,
+        "matchedAllocation": {
+          "key": "allocation-test",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3763 - Update shared SDK test data to have a test case for special characters](https://linear.app/eppo/issue/FF-3763/update-shared-sdk-test-data-to-have-a-test-case-for-special-characters)
🗨️ **Slack Thread:** ["...flag text encoding problem..."](https://eppo-group.slack.com/archives/C0541NTN6QH/p1735566355776199)

_Description:_
SDKs need to be able to handle special, non-ASCII characters. This PR adds a test that checks that by using strings with characters from a variety of languages as well as emojis, which all have non-ASCII values.