### PR TITLE
bug: fix broken test-sdk-packages github workflow in nodejs block

### DIFF
--- a/.github/workflows/test-sdk-packages.yml
+++ b/.github/workflows/test-sdk-packages.yml
@@ -35,7 +35,8 @@ jobs:
   test-node-sdk:
     strategy:
       fail-fast: false
-      matrix: ['linux']
+      matrix:
+        platform: ['linux']
     uses: ./.github/workflows/test-server-sdk.yml
     with:
       platform: ${{ matrix.platform }}


### PR DESCRIPTION
This was broken and package tests were not running. It is expected that the nodejs relay server is not starting, we will fix that later.

**reviewers** - please merge after approval.