### PR TITLE
[FF-4069] Update plain and obfuscated configs for flags for variation of type STRING with special characters in values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# SDK test data
+## Description
+This is a set of test cases bundled as UFC - universal flag configuration. The purpose of these test cases is to ensure SDK libraries are compliant with core application.
+
+## Dependencies
+Node.JS v18, Jest v29, Typescript v4
+
+## Usage
+1. install dependencies by runnning CLI command `yarn install`.
+2. Update content of the [flags-v1.json](ufc/flags-v1.json).
+3. Validate tests by runnning CLI command `yarn run validate:tests`. 
+4. Obfuscate file [flags-v1.json](ufc/flags-v1.json) by runnning CLI command `yarn run obfuscate:ufc`. It will update file [flags-v1-obfuscated.json](ufc/flags-v1-obfuscated.json) with obfuscated version of the file [flags-v1.json](ufc/flags-v1.json).

--- a/obfuscation/obfuscation.helper.ts
+++ b/obfuscation/obfuscation.helper.ts
@@ -1,0 +1,222 @@
+import { createHash } from 'crypto';
+
+import {
+  AllocationDto,
+  BanditFlagVariationDto,
+  BanditReferenceDto,
+  FlagDto,
+  RuleDto,
+  ShardDto,
+  SplitDto,
+  UFCFormatEnum,
+  UniversalFlagConfig,
+  VariationDto,
+  ITargetingRuleCondition
+} from './ufc.dto';
+
+export function md5Hash(input: string): string {
+  return createHash('md5').update(input).digest('hex');
+}
+
+export function base64Encode(input: string): string {
+  return Buffer.from(input).toString('base64');
+}
+
+export function obfuscateUniversalFlagConfig(ufc: UniversalFlagConfig): UniversalFlagConfig {
+  // Start building a new, obfuscated, UniversalFlagConfig
+  // We opted to do this instead of starting with a copy and mutating in-place for two reasons:
+  //   1. The code is easier to understand as it doesn't mutate in-place
+  //   2. If anything sensitive is added to the UFC but forgotten to be explicitly obfuscated, it could slip through
+  const obfuscatedUfc = new UniversalFlagConfig();
+
+  // update format
+  obfuscatedUfc.format = UFCFormatEnum.CLIENT;
+
+  // copy over fields that are not obfuscated
+  obfuscatedUfc.environment = ufc.environment;
+  if (ufc.createdAt) {
+    obfuscatedUfc.createdAt = ufc.createdAt;
+  }
+
+  // Obfuscate flags
+  obfuscatedUfc.flags = {};
+  Object.values(ufc.flags).forEach((flagDto) => {
+    const obfuscatedFlagDto = obfuscateFlag(flagDto);
+    obfuscatedUfc.flags[obfuscatedFlagDto.key] = obfuscatedFlagDto;
+  });
+
+  // Obfuscate bandits
+  if (ufc.bandits) {
+    const obfuscatedBandits: Record<string, BanditFlagVariationDto[]> = {};
+    Object.entries(ufc.bandits).forEach(([banditKey, banditFlagVariations]) => {
+      obfuscatedBandits[md5Hash(banditKey)] = banditFlagVariations.map(
+        obfuscateBanditFlagVariation,
+      );
+    });
+    obfuscatedUfc.bandits = obfuscatedBandits;
+  }
+  if (ufc.banditReferences) {
+    const obfuscatedBanditReferences: Record<string, BanditReferenceDto> = {};
+    Object.entries(ufc.banditReferences).forEach(([banditKey, banditReference]) => {
+      obfuscatedBanditReferences[md5Hash(banditKey)] = obfuscateBanditReference(banditReference);
+    });
+    obfuscatedUfc.banditReferences = obfuscatedBanditReferences;
+  }
+  return obfuscatedUfc;
+}
+
+function obfuscateFlag(flagDto: FlagDto): FlagDto {
+  const obfuscatedFlagDto = new FlagDto();
+
+  // We hash the flag key as the SDK will have an exact value to hash and compare
+  obfuscatedFlagDto.key = md5Hash(flagDto.key);
+
+  // copy over fields we are not obfuscating
+  obfuscatedFlagDto.enabled = flagDto.enabled;
+  obfuscatedFlagDto.variationType = flagDto.variationType;
+  obfuscatedFlagDto.totalShards = flagDto.totalShards;
+
+  // Obfuscate variations
+  obfuscatedFlagDto.variations = {};
+  Object.values(flagDto.variations).forEach((variationDto) => {
+    const obfuscatedVariationDto = obfuscateVariationDto(variationDto);
+    obfuscatedFlagDto.variations[obfuscatedVariationDto.key] = obfuscatedVariationDto;
+  });
+
+  // Obfuscate allocations (Note: we map as it's an array, and we want to preserve order)
+  obfuscatedFlagDto.allocations = flagDto.allocations.map(obfuscateAllocation);
+
+  return obfuscatedFlagDto;
+}
+
+function obfuscateVariationDto(variationDto: VariationDto): VariationDto {
+  const obfuscatedVariationDto = new VariationDto();
+  obfuscatedVariationDto.key = base64Encode(variationDto.key);
+
+  // Obfuscate any non-null/non-undefined (note loose comparison) values
+  obfuscatedVariationDto.value =
+    variationDto.value != null ? base64Encode(variationDto.value.toString()) : variationDto.value;
+
+  // Copy over algorithmType, unobfuscated, if present
+  if (variationDto.algorithmType) {
+    obfuscatedVariationDto.algorithmType = variationDto.algorithmType;
+  }
+
+  return obfuscatedVariationDto;
+}
+
+function obfuscateAllocation(allocationDto: AllocationDto): AllocationDto {
+  const obfuscatedAllocationDto = new AllocationDto();
+  obfuscatedAllocationDto.key = base64Encode(allocationDto.key);
+
+  // Leave doLog unobfuscated
+  obfuscatedAllocationDto.doLog = allocationDto.doLog;
+
+  // Obfuscate startAt and endAt, if present
+  if (allocationDto.startAt) {
+    obfuscatedAllocationDto.startAt = base64Encode(allocationDto.startAt);
+  }
+  if (allocationDto.endAt) {
+    obfuscatedAllocationDto.endAt = base64Encode(allocationDto.endAt);
+  }
+
+  // Obfuscate rules, if present, conserving order
+  if (allocationDto.rules) {
+    obfuscatedAllocationDto.rules = allocationDto.rules.map(obfuscateRule);
+  }
+
+  // Obfuscate splits, preserving order
+  obfuscatedAllocationDto.splits = allocationDto.splits.map(obfuscateSplit);
+
+  return obfuscatedAllocationDto;
+}
+
+function obfuscateRule(ruleDto: RuleDto): RuleDto {
+  const obfuscatedRuleDto = new RuleDto();
+
+  // Obfuscate conditions, preserving order
+  obfuscatedRuleDto.conditions = ruleDto.conditions.map(obfuscateConditionInPlace);
+  return obfuscatedRuleDto;
+}
+
+function obfuscateConditionInPlace(condition: ITargetingRuleCondition): ITargetingRuleCondition {
+  // Note: we return the object in one shot instead of building out the keys as it's an interface not a DTO object
+  return {
+    operator: md5Hash(condition.operator), // We can hash, as the SDK knows the set of possibilities
+    attribute: md5Hash(condition.attribute), // We can hash, as the SDK has the exact attributes to check for exact matches
+    value: obfuscateConditionValueForOperator(condition.value, condition.operator), // How we obfuscate depends on the operator
+  };
+}
+
+function obfuscateConditionValueForOperator<T extends ITargetingRuleCondition>(
+  value: T['value'],
+  operator: string,
+): string | string[] {
+  if (['ONE_OF', 'NOT_ONE_OF', 'IS_NULL'].includes(operator)) {
+    // We hash values when it's an exact comparison because we can compare hashes
+    if (Array.isArray(value)) {
+      return value.map(md5Hash);
+    } else {
+      return md5Hash(value.toString());
+    }
+  }
+
+  // Everything else (e.g., inequalities, regular expressions) we need to just encode, so that we
+  // can reverse for evaluation
+  return base64Encode(value.toString());
+}
+
+function obfuscateSplit(splitDto: SplitDto): SplitDto {
+  const obfuscatedSplitDto = new SplitDto();
+  obfuscatedSplitDto.variationKey = base64Encode(splitDto.variationKey);
+
+  // Obfuscate shards, if present, as their keys could contain sensitive information
+  if (splitDto.shards) {
+    obfuscatedSplitDto.shards = splitDto.shards.map(obfuscateShard);
+  }
+
+  // Obfuscate extra logging, if present
+  if (splitDto.extraLogging) {
+    obfuscatedSplitDto.extraLogging = {};
+    for (const [extraLoggingKey, extraLoggingValue] of Object.entries(splitDto.extraLogging)) {
+      obfuscatedSplitDto.extraLogging[base64Encode(extraLoggingKey)] = base64Encode(
+        extraLoggingValue,
+      );
+    }
+  }
+
+  return obfuscatedSplitDto;
+}
+
+function obfuscateShard(shardDto: ShardDto): ShardDto {
+  const obfuscatedShardDto = new ShardDto();
+
+  // Copy over ranges unobfuscated
+  obfuscatedShardDto.ranges = structuredClone(shardDto.ranges);
+
+  // Obfuscate salt
+  obfuscatedShardDto.salt = base64Encode(shardDto.salt);
+
+  return obfuscatedShardDto;
+}
+
+function obfuscateBanditReference(properties: BanditReferenceDto) {
+  const obfuscatedProperties = new BanditReferenceDto();
+  obfuscatedProperties.modelVersion = properties.modelVersion
+    ? md5Hash(properties.modelVersion)
+    : null;
+  obfuscatedProperties.flagVariations = properties.flagVariations.map(obfuscateBanditFlagVariation);
+  return obfuscatedProperties;
+}
+
+function obfuscateBanditFlagVariation(banditFlagVariation: BanditFlagVariationDto) {
+  const obfuscatedBanditFlagVariation = new BanditFlagVariationDto();
+  // Everything can be hashed as we'll have the values and be doing direct lookups
+  obfuscatedBanditFlagVariation.key = md5Hash(banditFlagVariation.key);
+  obfuscatedBanditFlagVariation.flagKey = md5Hash(banditFlagVariation.flagKey);
+  obfuscatedBanditFlagVariation.allocationKey = md5Hash(banditFlagVariation.allocationKey);
+  obfuscatedBanditFlagVariation.variationKey = md5Hash(banditFlagVariation.variationKey);
+  obfuscatedBanditFlagVariation.variationValue = md5Hash(banditFlagVariation.variationValue);
+
+  return obfuscatedBanditFlagVariation;
+}

--- a/obfuscation/obfuscation.spec.ts
+++ b/obfuscation/obfuscation.spec.ts
@@ -1,0 +1,16 @@
+
+import * as fs from "fs";
+import * as path from "path";
+import * as ufcFlags from "../ufc/flags-v1.json";
+import { obfuscateUniversalFlagConfig } from "./obfuscation.helper";
+import { UniversalFlagConfig } from "./ufc.dto";
+
+describe('Obfuscate UFC config', () => {
+
+  it("Obfuscate UFC flags config", () => {
+    const ufc = ufcFlags as UniversalFlagConfig;
+    const resultObfuscatedUfc = obfuscateUniversalFlagConfig(ufc);
+    fs.writeFileSync(path.join(__dirname, "../ufc/flags-v1-obfuscated.json"), JSON.stringify(resultObfuscatedUfc, null, 2));
+  });
+
+});

--- a/obfuscation/ufc.dto.ts
+++ b/obfuscation/ufc.dto.ts
@@ -1,0 +1,98 @@
+export interface ITargetingRuleCondition {
+  operator: string;
+
+  attribute: string;
+
+  value: number | boolean | string | string[];
+}
+
+export enum ExperimentVariationAlgorithmTypeEnum {
+  CONSTANT = 'CONSTANT',
+  CONTEXTUAL_BANDIT = 'CONTEXTUAL_BANDIT',
+}
+
+export enum ExperimentVariationValueTypeEnum {
+  BOOLEAN = 'BOOLEAN',
+  INTEGER = 'INTEGER',
+  JSON = 'JSON',
+  NUMERIC = 'NUMERIC',
+  STRING = 'STRING',
+}
+
+export enum UFCFormatEnum {
+  SERVER = 'SERVER',
+  CLIENT = 'CLIENT',
+}
+
+export class UniversalFlagConfig {
+  createdAt!: string; // ISODate
+  format!: UFCFormatEnum;
+  environment!: EnvironmentDto; // used for evaluation "details"
+  flags!: Record<string, FlagDto>;
+  banditReferences?: Record<string, BanditReferenceDto>;
+  /**
+   * @deprecated Moving bandit information to `banditReferences`
+   */
+  bandits?: Record<string, BanditFlagVariationDto[]>;
+}
+
+export class EnvironmentDto {
+  name!: string;
+}
+
+export class FlagDto {
+  key!: string;
+  enabled!: boolean;
+  variationType!: ExperimentVariationValueTypeEnum;
+  variations!: Record<string, VariationDto>;
+  allocations!: AllocationDto[];
+  totalShards!: number;
+}
+
+export class VariationDto {
+  key!: string;
+  value!: boolean | number | string; // JSON represented as string
+  algorithmType?: ExperimentVariationAlgorithmTypeEnum;
+}
+
+export class AllocationDto {
+  key!: string;
+  rules?: RuleDto[];
+  startAt?: string; // ISODate
+  endAt?: string; // ISODate
+  splits!: SplitDto[];
+  doLog!: boolean;
+}
+
+export class RuleDto {
+  conditions!: ITargetingRuleCondition[];
+}
+
+export class SplitDto {
+  variationKey!: string;
+  shards!: ShardDto[];
+  extraLogging?: Record<string, string>;
+}
+
+export class ShardDto {
+  salt!: string;
+  ranges!: RangeDto[];
+}
+
+export class RangeDto {
+  start!: number; // inclusive
+  end!: number; // exclusive
+}
+
+export class BanditFlagVariationDto {
+  key!: string;
+  flagKey!: string;
+  allocationKey!: string;
+  variationKey!: string;
+  variationValue!: string;
+}
+
+export class BanditReferenceDto {
+  modelVersion!: string | null;
+  flagVariations!: BanditFlagVariationDto[];
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">=18.x"
   },
   "scripts": {
-    "validate:tests": "jest ./test-validation"
+    "validate:tests": "jest ./test-validation",
+    "obfuscate:ufc": "jest ./obfuscation"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1,9 +1,9 @@
 {
-  "createdAt": "2024-04-17T19:40:53.716Z",
   "format": "CLIENT",
   "environment": {
     "name": "Test"
   },
+  "createdAt": "2024-04-17T19:40:53.716Z",
   "flags": {
     "73fcc84c69e49e31fe16a29b2b1f803b": {
       "key": "73fcc84c69e49e31fe16a29b2b1f803b",
@@ -405,6 +405,76 @@
             {
               "variationKey": "NQ==",
               "shards": []
+            }
+          ]
+        }
+      ]
+    },
+    "1d23cbd300895799fda462f81ec4e135": {
+      "key": "1d23cbd300895799fda462f81ec4e135",
+      "enabled": true,
+      "variationType": "STRING",
+      "totalShards": 10000,
+      "variations": {
+        "ZW1wdHlfc3RyaW5n": {
+          "key": "ZW1wdHlfc3RyaW5n",
+          "value": ""
+        },
+        "bm9uX2VtcHR5": {
+          "key": "bm9uX2VtcHR5",
+          "value": "bm9uX2VtcHR5"
+        }
+      },
+      "allocations": [
+        {
+          "key": "YWxsb2NhdGlvbi1lbXB0eQ==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "05015086bdd8402218f6aad6528bef08",
+                  "attribute": "e909c2d7067ea37437cf97fe11d91bd0",
+                  "value": "VVM="
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "ZW1wdHlfc3RyaW5n",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ],
+                  "salt": "YWxsb2NhdGlvbi1lbXB0eS1zaGFyZHM="
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0",
+          "doLog": true,
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "bm9uX2VtcHR5",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ],
+                  "salt": "YWxsb2NhdGlvbi1lbXB0eS1zaGFyZHM="
+                }
+              ]
             }
           ]
         }
@@ -1188,92 +1258,14 @@
       ]
     },
     "eab426e60c686e18da04981a4d53c837": {
-      "allocations": [
-        {
-          "doLog": true,
-          "key": "YWxsb2NhdGlvbi10ZXN0",
-          "splits": [
-            {
-              "shards": [
-                {
-                  "ranges": [
-                    {
-                      "end": 2500,
-                      "start": 0
-                    }
-                  ],
-                  "salt": "c3BsaXQtanNvbi1mbGFn"
-                }
-              ],
-              "variationKey": "ZGU="
-            },
-            {
-              "shards": [
-                {
-                  "ranges": [
-                    {
-                      "end": 5000,
-                      "start": 2500
-                    }
-                  ],
-                  "salt": "c3BsaXQtanNvbi1mbGFn"
-                }
-              ],
-              "variationKey": "dWE="
-            },
-            {
-              "shards": [
-                {
-                  "ranges": [
-                    {
-                      "end": 7500,
-                      "start": 5000
-                    }
-                  ],
-                  "salt": "c3BsaXQtanNvbi1mbGFn"
-                }
-              ],
-              "variationKey": "emg="
-            },
-            {
-              "shards": [
-                {
-                  "ranges": [
-                    {
-                      "end": 10000,
-                      "start": 7500
-                    }
-                  ],
-                  "salt": "c3BsaXQtanNvbi1mbGFn"
-                }
-              ],
-              "variationKey": "ZW1vamk="
-            }
-          ]
-        },
-        {
-          "doLog": false,
-          "key": "YWxsb2NhdGlvbi1kZWZhdWx0",
-          "splits": [
-            {
-              "shards": [],
-              "variationKey": "ZGU="
-            }
-          ]
-        }
-      ],
-      "enabled": true,
       "key": "eab426e60c686e18da04981a4d53c837",
-      "totalShards": 10000,
+      "enabled": true,
       "variationType": "JSON",
+      "totalShards": 10000,
       "variations": {
         "ZGU=": {
           "key": "ZGU=",
           "value": "eyJhIjogImvDvG1tZXJ0IiwgImIiOiAic2Now7ZuIn0="
-        },
-        "ZW1vamk=": {
-          "key": "ZW1vamk=",
-          "value": "eyJhIjogIvCfpJciLCAiYiI6ICLwn4y4In0="
         },
         "dWE=": {
           "key": "dWE=",
@@ -1282,79 +1274,1878 @@
         "emg=": {
           "key": "emg=",
           "value": "eyJhIjogIueFp+mhviIsICJiIjogIua8guS6riJ9"
-        }
-      }
-    },
-    "1d23cbd300895799fda462f81ec4e135": {
-      "key": "1d23cbd300895799fda462f81ec4e135",
-      "comment": "Testing the empty string as a variation value",
-      "enabled": true,
-      "variationType": "STRING",
-      "variations": {
-        "ZW1wdHlfc3RyaW5n": {
-          "key": "ZW1wdHlfc3RyaW5n",
-          "value": ""
         },
-        "bm9uX2VtcHR5": {
-          "key": "bm9uX2VtcHR5",
-          "value": "bm9uX2VtcHR5"
+        "ZW1vamk=": {
+          "key": "ZW1vamk=",
+          "value": "eyJhIjogIvCfpJciLCAiYiI6ICLwn4y4In0="
         }
       },
       "allocations": [
         {
-          "key": "YWxsb2NhdGlvbi1lbXB0eQ==",
+          "key": "YWxsb2NhdGlvbi10ZXN0",
+          "doLog": true,
+          "splits": [
+            {
+              "variationKey": "ZGU=",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 2500
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ]
+            },
+            {
+              "variationKey": "dWE=",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 2500,
+                      "end": 5000
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ]
+            },
+            {
+              "variationKey": "emg=",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 7500
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ]
+            },
+            {
+              "variationKey": "ZW1vamk=",
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "start": 7500,
+                      "end": 10000
+                    }
+                  ],
+                  "salt": "c3BsaXQtanNvbi1mbGFn"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi1kZWZhdWx0",
+          "doLog": false,
+          "splits": [
+            {
+              "variationKey": "ZGU=",
+              "shards": []
+            }
+          ]
+        }
+      ]
+    },
+    "de1a3767d9f3993c1620300aebd320aa": {
+      "key": "de1a3767d9f3993c1620300aebd320aa",
+      "enabled": true,
+      "variationType": "STRING",
+      "totalShards": 10000,
+      "variations": {
+        "c3RyaW5nX3dpdGhfc3BhY2Vz": {
+          "key": "c3RyaW5nX3dpdGhfc3BhY2Vz",
+          "value": "IGEgYiBjIGQgZSBmIA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfc3BhY2U=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfc3BhY2U=",
+          "value": "IA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zcGFjZXM=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zcGFjZXM=",
+          "value": "ICAgICAgIA=="
+        },
+        "c3RyaW5nX3dpdGhfZG90cw==": {
+          "key": "c3RyaW5nX3dpdGhfZG90cw==",
+          "value": "LmEuYi5jLmQuZS5mLg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfZG90": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfZG90",
+          "value": "Lg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kb3Rz": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kb3Rz",
+          "value": "Li4uLi4uLg=="
+        },
+        "c3RyaW5nX3dpdGhfY29tYXM=": {
+          "key": "c3RyaW5nX3dpdGhfY29tYXM=",
+          "value": "LGEsYixjLGQsZSxmLA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfY29tYQ==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfY29tYQ==",
+          "value": "LA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jb21hcw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jb21hcw==",
+          "value": "LCwsLCwsLA=="
+        },
+        "c3RyaW5nX3dpdGhfY29sb25z": {
+          "key": "c3RyaW5nX3dpdGhfY29sb25z",
+          "value": "OmE6YjpjOmQ6ZTpmOg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfY29sb24=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfY29sb24=",
+          "value": "Og=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jb2xvbnM=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jb2xvbnM=",
+          "value": "Ojo6Ojo6Og=="
+        },
+        "c3RyaW5nX3dpdGhfc2VtaWNvbG9ucw==": {
+          "key": "c3RyaW5nX3dpdGhfc2VtaWNvbG9ucw==",
+          "value": "O2E7YjtjO2Q7ZTtmOw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfc2VtaWNvbG9u": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfc2VtaWNvbG9u",
+          "value": "Ow=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zZW1pY29sb25z": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zZW1pY29sb25z",
+          "value": "Ozs7Ozs7Ow=="
+        },
+        "c3RyaW5nX3dpdGhfc2xhc2hlcw==": {
+          "key": "c3RyaW5nX3dpdGhfc2xhc2hlcw==",
+          "value": "L2EvYi9jL2QvZS9mLw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfc2xhc2g=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfc2xhc2g=",
+          "value": "Lw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zbGFzaGVz": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zbGFzaGVz",
+          "value": "Ly8vLy8vLw=="
+        },
+        "c3RyaW5nX3dpdGhfZGFzaGVz": {
+          "key": "c3RyaW5nX3dpdGhfZGFzaGVz",
+          "value": "LWEtYi1jLWQtZS1mLQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfZGFzaA==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfZGFzaA==",
+          "value": "LQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kYXNoZXM=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kYXNoZXM=",
+          "value": "LS0tLS0tLQ=="
+        },
+        "c3RyaW5nX3dpdGhfdW5kZXJzY29yZXM=": {
+          "key": "c3RyaW5nX3dpdGhfdW5kZXJzY29yZXM=",
+          "value": "X2FfYl9jX2RfZV9mXw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfdW5kZXJzY29yZQ==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfdW5kZXJzY29yZQ==",
+          "value": "Xw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV91bmRlcnNjb3Jlcw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV91bmRlcnNjb3Jlcw==",
+          "value": "X19fX19fXw=="
+        },
+        "c3RyaW5nX3dpdGhfcGx1c19zaWducw==": {
+          "key": "c3RyaW5nX3dpdGhfcGx1c19zaWducw==",
+          "value": "K2ErYitjK2QrZStmKw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfcGx1c19zaWdu": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfcGx1c19zaWdu",
+          "value": "Kw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9wbHVzX3NpZ25z": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9wbHVzX3NpZ25z",
+          "value": "KysrKysrKw=="
+        },
+        "c3RyaW5nX3dpdGhfZXF1YWxfc2lnbnM=": {
+          "key": "c3RyaW5nX3dpdGhfZXF1YWxfc2lnbnM=",
+          "value": "PWE9Yj1jPWQ9ZT1mPQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfZXF1YWxfc2lnbg==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfZXF1YWxfc2lnbg==",
+          "value": "PQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9lcXVhbF9zaWducw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9lcXVhbF9zaWducw==",
+          "value": "PT09PT09PQ=="
+        },
+        "c3RyaW5nX3dpdGhfZG9sbGFyX3NpZ25z": {
+          "key": "c3RyaW5nX3dpdGhfZG9sbGFyX3NpZ25z",
+          "value": "JGEkYiRjJGQkZSRmJA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfZG9sbGFyX3NpZ24=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfZG9sbGFyX3NpZ24=",
+          "value": "JA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kb2xsYXJfc2lnbnM=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kb2xsYXJfc2lnbnM=",
+          "value": "JCQkJCQkJA=="
+        },
+        "c3RyaW5nX3dpdGhfYXRfc2lnbnM=": {
+          "key": "c3RyaW5nX3dpdGhfYXRfc2lnbnM=",
+          "value": "QGFAYkBjQGRAZUBmQA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfYXRfc2lnbg==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfYXRfc2lnbg==",
+          "value": "QA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hdF9zaWducw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hdF9zaWducw==",
+          "value": "QEBAQEBAQA=="
+        },
+        "c3RyaW5nX3dpdGhfYW1wX3NpZ25z": {
+          "key": "c3RyaW5nX3dpdGhfYW1wX3NpZ25z",
+          "value": "JmEmYiZjJmQmZSZmJg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfYW1wX3NpZ24=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfYW1wX3NpZ24=",
+          "value": "Jg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hbXBfc2lnbnM=": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hbXBfc2lnbnM=",
+          "value": "JiYmJiYmJg=="
+        },
+        "c3RyaW5nX3dpdGhfaGFzaF9zaWducw==": {
+          "key": "c3RyaW5nX3dpdGhfaGFzaF9zaWducw==",
+          "value": "I2EjYiNjI2QjZSNmIw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfaGFzaF9zaWdu": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfaGFzaF9zaWdu",
+          "value": "Iw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9oYXNoX3NpZ25z": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9oYXNoX3NpZ25z",
+          "value": "IyMjIyMjIw=="
+        },
+        "c3RyaW5nX3dpdGhfcGVyY2VudGFnZV9zaWducw==": {
+          "key": "c3RyaW5nX3dpdGhfcGVyY2VudGFnZV9zaWducw==",
+          "value": "JWElYiVjJWQlZSVmJQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfcGVyY2VudGFnZV9zaWdu": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfcGVyY2VudGFnZV9zaWdu",
+          "value": "JQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9wZXJjZW50YWdlX3NpZ25z": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9wZXJjZW50YWdlX3NpZ25z",
+          "value": "JSUlJSUlJQ=="
+        },
+        "c3RyaW5nX3dpdGhfdGlsZGVfc2lnbnM=": {
+          "key": "c3RyaW5nX3dpdGhfdGlsZGVfc2lnbnM=",
+          "value": "fmF+Yn5jfmR+ZX5mfg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfdGlsZGVfc2lnbg==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfdGlsZGVfc2lnbg==",
+          "value": "fg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV90aWxkZV9zaWducw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV90aWxkZV9zaWducw==",
+          "value": "fn5+fn5+fg=="
+        },
+        "c3RyaW5nX3dpdGhfYXN0ZXJpeF9zaWducw==": {
+          "key": "c3RyaW5nX3dpdGhfYXN0ZXJpeF9zaWducw==",
+          "value": "KmEqYipjKmQqZSpmKg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfYXN0ZXJpeF9zaWdu": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfYXN0ZXJpeF9zaWdu",
+          "value": "Kg=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hc3Rlcml4X3NpZ25z": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hc3Rlcml4X3NpZ25z",
+          "value": "KioqKioqKg=="
+        },
+        "c3RyaW5nX3dpdGhfc2luZ2xlX3F1b3Rlcw==": {
+          "key": "c3RyaW5nX3dpdGhfc2luZ2xlX3F1b3Rlcw==",
+          "value": "J2EnYidjJ2QnZSdmJw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfc2luZ2xlX3F1b3Rl": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfc2luZ2xlX3F1b3Rl",
+          "value": "Jw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zaW5nbGVfcXVvdGVz": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zaW5nbGVfcXVvdGVz",
+          "value": "JycnJycnJw=="
+        },
+        "c3RyaW5nX3dpdGhfcXVlc3Rpb25fbWFya3M=": {
+          "key": "c3RyaW5nX3dpdGhfcXVlc3Rpb25fbWFya3M=",
+          "value": "P2E/Yj9jP2Q/ZT9mPw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfcXVlc3Rpb25fbWFyaw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfcXVlc3Rpb25fbWFyaw==",
+          "value": "Pw=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9xdWVzdGlvbl9tYXJrcw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9xdWVzdGlvbl9tYXJrcw==",
+          "value": "Pz8/Pz8/Pw=="
+        },
+        "c3RyaW5nX3dpdGhfZXhjbGFtYXRpb25fbWFya3M=": {
+          "key": "c3RyaW5nX3dpdGhfZXhjbGFtYXRpb25fbWFya3M=",
+          "value": "IWEhYiFjIWQhZSFmIQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfZXhjbGFtYXRpb25fbWFyaw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfZXhjbGFtYXRpb25fbWFyaw==",
+          "value": "IQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9leGNsYW1hdGlvbl9tYXJrcw==": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9leGNsYW1hdGlvbl9tYXJrcw==",
+          "value": "ISEhISEhIQ=="
+        },
+        "c3RyaW5nX3dpdGhfb3BlbmluZ19wYXJlbnRoZXNlcw==": {
+          "key": "c3RyaW5nX3dpdGhfb3BlbmluZ19wYXJlbnRoZXNlcw==",
+          "value": "KGEoYihjKGQoZShmKA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfb3BlbmluZ19wYXJlbnRoZXNl": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfb3BlbmluZ19wYXJlbnRoZXNl",
+          "value": "KA=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9vcGVuaW5nX3BhcmVudGhlc2Vz": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9vcGVuaW5nX3BhcmVudGhlc2Vz",
+          "value": "KCgoKCgoKA=="
+        },
+        "c3RyaW5nX3dpdGhfY2xvc2luZ19wYXJlbnRoZXNlcw==": {
+          "key": "c3RyaW5nX3dpdGhfY2xvc2luZ19wYXJlbnRoZXNlcw==",
+          "value": "KWEpYiljKWQpZSlmKQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9vbmVfY2xvc2luZ19wYXJlbnRoZXNl": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9vbmVfY2xvc2luZ19wYXJlbnRoZXNl",
+          "value": "KQ=="
+        },
+        "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jbG9zaW5nX3BhcmVudGhlc2Vz": {
+          "key": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jbG9zaW5nX3BhcmVudGhlc2Vz",
+          "value": "KSkpKSkpKQ=="
+        }
+      },
+      "allocations": [
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3NwYWNlcw==",
+          "doLog": true,
           "rules": [
             {
               "conditions": [
                 {
-                  "attribute": "e909c2d7067ea37437cf97fe11d91bd0",
-                  "operator": "05015086bdd8402218f6aad6528bef08",
-                  "value": "VVM="
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "6012b5f3fdae25d9094700420e1e34de",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
                 }
               ]
             }
           ],
           "splits": [
             {
-              "variationKey": "ZW1wdHlfc3RyaW5n",
-              "shards": [
-                {
-                  "salt": "YWxsb2NhdGlvbi1lbXB0eS1zaGFyZHM=",
-                  "ranges": [
-                    {
-                      "start": 0,
-                      "end": 10000
-                    }
-                  ]
-                }
-              ]
+              "variationKey": "c3RyaW5nX3dpdGhfc3BhY2Vz",
+              "shards": []
             }
-          ],
-          "doLog": true
+          ]
         },
         {
-          "key": "YWxsb2NhdGlvbi10ZXN0",
-          "rules": [],
-          "splits": [
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3NwYWNl",
+          "doLog": true,
+          "rules": [
             {
-              "variationKey": "bm9uX2VtcHR5",
-              "shards": [
+              "conditions": [
                 {
-                  "salt": "YWxsb2NhdGlvbi1lbXB0eS1zaGFyZHM=",
-                  "ranges": [
-                    {
-                      "start": 0,
-                      "end": 10000
-                    }
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "7520b8214026f64f2c89b4fc8b8825b8",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
                   ]
                 }
               ]
             }
           ],
-          "doLog": true
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfc3BhY2U=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfc3BhY2Vz",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "6450cd1b1b0e0ee591f76566f4a74d01",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zcGFjZXM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2RvdHM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "b816cbbf077e32f3ae5a5deb96bc5e40",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfZG90cw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2RvdA==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "7520be130e5977636a5e69f89f4c9987",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfZG90",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfZG90cw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "ede683b3939bae0e683312b15918d304",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kb3Rz",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2NvbWFz",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "78644a7bc4d33e35f7f258ac5524ddce",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfY29tYXM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2NvbWE=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "8dec459597a9db2c4d1f528d038e0c3d",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfY29tYQ==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfY29tYXM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "4d36d20499443fb3b348a2e4b4e045eb",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jb21hcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2NvbG9ucw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "7196fbee634fb38a7e8d3f5cbcea4865",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfY29sb25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2NvbG9u",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "0017d628e2313bd2de53b7a76279324b",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfY29sb24=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfY29sb25z",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "add442d63f11488aead4a8e4d1825a17",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jb2xvbnM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3NlbWljb2xvbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "29bfcec952a509971ff2ae878af7b7c3",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfc2VtaWNvbG9ucw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3NlbWljb2xvbg==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "67cfc136488da373cabbb56e8f243b3e",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfc2VtaWNvbG9u",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfc2VtaWNvbG9ucw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "da6f8b154ff58cf1689493e718be02a6",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zZW1pY29sb25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3NsYXNoZXM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "0973ffc4fe97a23ced895bd2a45736d8",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfc2xhc2hlcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3NsYXNo",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "b5eab4e5c4404abcf346ee6672677eb7",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfc2xhc2g=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfc2xhc2hlcw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "789d96046c947c02b1aba5ccb35c7e18",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zbGFzaGVz",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2Rhc2hlcw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "a85d3f44ef7363adc0e6330331eb37bb",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfZGFzaGVz",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2Rhc2g=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "74df5ae6328deb9fb4a4ee35dd528eaf",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfZGFzaA==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfZGFzaGVz",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "8e58eba3f98790462cc9826a58bb724f",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kYXNoZXM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3VuZGVyc2NvcmVz",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "c8a9bd32c740825bc1bab5afda604c48",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfdW5kZXJzY29yZXM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3VuZGVyc2NvcmU=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "71b6051d3cb22810aa4f71b4357e57ab",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfdW5kZXJzY29yZQ==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfdW5kZXJzY29yZXM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "86cf4300f7ab1c9f2ef05a446a0fabe1",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV91bmRlcnNjb3Jlcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3BsdXNfc2lnbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "be8579389961ccaef43ee53fd2be1b6b",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfcGx1c19zaWducw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3BsdXNfc2lnbg==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "666a106655cf9b8e78f6940f9c23b421",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfcGx1c19zaWdu",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfcGx1c19zaWducw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "3da52458f9adf26081d02c4974a52904",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9wbHVzX3NpZ25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2VxdWFsX3NpZ25z",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "e66d9fbaa933ab574b31e58c8771a3aa",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfZXF1YWxfc2lnbnM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2VxdWFsX3NpZ24=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "92cba9a9395d1879734e5f876f0aba42",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfZXF1YWxfc2lnbg==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfZXF1YWxfc2lnbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "77b3873d23f83bc0d8e56554d91670b2",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9lcXVhbF9zaWducw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2RvbGxhcl9zaWducw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "e1151a808f081ff31aaebba94db9da5e",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfZG9sbGFyX3NpZ25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2RvbGxhcl9zaWdu",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "084f2b4a9a1a67cdbc8931fd4a18b3ea",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfZG9sbGFyX3NpZ24=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfZG9sbGFyX3NpZ25z",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "0da9f7cc8bfea5f95e17a4b3e56813d0",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9kb2xsYXJfc2lnbnM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2F0X3NpZ25z",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "9e1e061223d86d9b9919de937887e821",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfYXRfc2lnbnM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2F0X3NpZ24=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "c37509ab4724c132f30a446256bba243",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfYXRfc2lnbg==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfYXRfc2lnbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "6589cccac4677bb443e1cac52dd3fd95",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hdF9zaWducw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2FtcF9zaWducw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "9d5cb1ed1d24728c63b333ab10e4de68",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfYW1wX3NpZ25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2FtcF9zaWdu",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "dc458d5013caf60dcb821a1a62cdb8b1",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfYW1wX3NpZ24=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfYW1wX3NpZ25z",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "936bda8989074c8b79fa75a9b6f82528",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hbXBfc2lnbnM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2hhc2hfc2lnbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "cef7eb322d282a3d5ba54b4026495d3a",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfaGFzaF9zaWducw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2hhc2hfc2lnbg==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "2026f4d65474d51b0adb6d4b8840c8d6",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfaGFzaF9zaWdu",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfaGFzaF9zaWducw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "eb7a011116edd4efa3423cf0f3a465b1",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9oYXNoX3NpZ25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3BlcmNlbnRhZ2Vfc2lnbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "206ab862f2c2fbf290b0a1bee37a2684",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfcGVyY2VudGFnZV9zaWducw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3BlcmNlbnRhZ2Vfc2lnbg==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "d6cd9b82d32bb7fb357b18729191010e",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfcGVyY2VudGFnZV9zaWdu",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfcGVyY2VudGFnZV9zaWducw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "27d44941a2ce55477ff057890c3fc05d",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9wZXJjZW50YWdlX3NpZ25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3RpbGRlX3NpZ25z",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "5e034525d53c7bb072a73cfd8c7b53e5",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfdGlsZGVfc2lnbnM=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3RpbGRlX3NpZ24=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "91519207f62a80c861583ac9f877466b",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfdGlsZGVfc2lnbg==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfdGlsZGVfc2lnbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "fb1bdbffa1892d0a6160333498b3a782",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV90aWxkZV9zaWducw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2FzdGVyaXhfc2lnbnM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "4b365b0c24a2cdd9cb58a73fbb09d6f7",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfYXN0ZXJpeF9zaWducw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2FzdGVyaXhfc2lnbg==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "b6820a87e4c0a9a1467a4f8a7da1f1e1",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfYXN0ZXJpeF9zaWdu",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfYXN0ZXJpeF9zaWducw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "3b8e8b8f2a76a3e5d80207658a8c11c8",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9hc3Rlcml4X3NpZ25z",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3NpbmdsZV9xdW90ZXM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "89647fb00d7a1944ef64e554c9e87e1d",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfc2luZ2xlX3F1b3Rlcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3NpbmdsZV9xdW90ZQ==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "31d52f5ef86da32b02351ccb8e9c324f",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfc2luZ2xlX3F1b3Rl",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfc2luZ2xlX3F1b3Rlcw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "fe81d7e768e6dc8defe7360d289f39d5",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9zaW5nbGVfcXVvdGVz",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX3F1ZXN0aW9uX21hcmtz",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "b0e8d750bcfeeec73385e9911a0792d5",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfcXVlc3Rpb25fbWFya3M=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX3F1ZXN0aW9uX21hcms=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "74e2f9bcf9bc048bd4acdda4ca9aaf8e",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfcXVlc3Rpb25fbWFyaw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfcXVlc3Rpb25fbWFya3M=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "8a1d456f3bdd88898e3919ba8631ae2f",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9xdWVzdGlvbl9tYXJrcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2V4Y2xhbWF0aW9uX21hcmtz",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "82c80b90eb021bf7d2461782039666e2",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfZXhjbGFtYXRpb25fbWFya3M=",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2V4Y2xhbWF0aW9uX21hcms=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "4608490528dc4ae9397a89edbb3237af",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfZXhjbGFtYXRpb25fbWFyaw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfZXhjbGFtYXRpb25fbWFya3M=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "dd8bb958307fc147b1f799d51888b962",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9leGNsYW1hdGlvbl9tYXJrcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29wZW5pbmdfcGFyZW50aGVzZXM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "069d8f4cdc0c0d6a2b3210d15f4e7b55",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb3BlbmluZ19wYXJlbnRoZXNlcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX29wZW5pbmdfcGFyZW50aGVzZQ==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "649a4637860b4bd4ec9bb8e128ba9635",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfb3BlbmluZ19wYXJlbnRoZXNl",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfb3BlbmluZ19wYXJlbnRoZXNlcw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "1dbb847658dec6045479499da9c0ab14",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9vcGVuaW5nX3BhcmVudGhlc2Vz",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX2Nsb3NpbmdfcGFyZW50aGVzZXM=",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "663d8c5d7428b21da9a589f899d1b355",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfY2xvc2luZ19wYXJlbnRoZXNlcw==",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfb25lX2Nsb3NpbmdfcGFyZW50aGVzZQ==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "b4a5a171b5babc40611979c6616ca7f0",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9vbmVfY2xvc2luZ19wYXJlbnRoZXNl",
+              "shards": []
+            }
+          ]
+        },
+        {
+          "key": "YWxsb2NhdGlvbi10ZXN0LXN0cmluZ193aXRoX29ubHlfbXVsdGlwbGVfY2xvc2luZ19wYXJlbnRoZXNlcw==",
+          "doLog": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "attribute": "9d491fc1d4db662214cc1f91a128bf39",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "c3RyaW5nX3dpdGhfb25seV9tdWx0aXBsZV9jbG9zaW5nX3BhcmVudGhlc2Vz",
+              "shards": []
+            }
+          ]
         }
-      ],
-      "totalShards": 10000
+      ]
     }
   }
 }

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1355,6 +1355,1799 @@
           "doLog": false
         }
       ]
+    },
+    "string_flag_with_special_characters": {
+      "key": "string_flag_with_special_characters",
+      "enabled": true,
+      "comment": "Testing the string with special characters and spaces",
+      "variationType": "STRING",
+      "variations": {
+        "string_with_spaces": {
+          "key": "string_with_spaces",
+          "value": " a b c d e f "
+        },
+        "string_with_only_one_space": {
+          "key": "string_with_only_one_space",
+          "value": " "
+        },
+        "string_with_only_multiple_spaces": {
+          "key": "string_with_only_multiple_spaces",
+          "value": "       "
+        },
+        "string_with_dots": {
+          "key": "string_with_dots",
+          "value": ".a.b.c.d.e.f."
+        },
+        "string_with_only_one_dot": {
+          "key": "string_with_only_one_dot",
+          "value": "."
+        },
+        "string_with_only_multiple_dots": {
+          "key": "string_with_only_multiple_dots",
+          "value": "......."
+        },
+        "string_with_comas": {
+          "key": "string_with_comas",
+          "value": ",a,b,c,d,e,f,"
+        },
+        "string_with_only_one_coma": {
+          "key": "string_with_only_one_coma",
+          "value": ","
+        },
+        "string_with_only_multiple_comas": {
+          "key": "string_with_only_multiple_comas",
+          "value": ",,,,,,,"
+        },
+        "string_with_colons": {
+          "key": "string_with_colons",
+          "value": ":a:b:c:d:e:f:"
+        },
+        "string_with_only_one_colon": {
+          "key": "string_with_only_one_colon",
+          "value": ":"
+        },
+        "string_with_only_multiple_colons": {
+          "key": "string_with_only_multiple_colons",
+          "value": ":::::::"
+        },
+        "string_with_semicolons": {
+          "key": "string_with_semicolons",
+          "value": ";a;b;c;d;e;f;"
+        },
+        "string_with_only_one_semicolon": {
+          "key": "string_with_only_one_semicolon",
+          "value": ";"
+        },
+        "string_with_only_multiple_semicolons": {
+          "key": "string_with_only_multiple_semicolons",
+          "value": ";;;;;;;"
+        },
+        "string_with_slashes": {
+          "key": "string_with_slashes",
+          "value": "/a/b/c/d/e/f/"
+        },
+        "string_with_only_one_slash": {
+          "key": "string_with_only_one_slash",
+          "value": "/"
+        },
+        "string_with_only_multiple_slashes": {
+          "key": "string_with_only_multiple_slashes",
+          "value": "///////"
+        },
+        "string_with_dashes": {
+          "key": "string_with_dashes",
+          "value": "-a-b-c-d-e-f-"
+        },
+        "string_with_only_one_dash": {
+          "key": "string_with_only_one_dash",
+          "value": "-"
+        },
+        "string_with_only_multiple_dashes": {
+          "key": "string_with_only_multiple_dashes",
+          "value": "-------"
+        },
+        "string_with_underscores": {
+          "key": "string_with_underscores",
+          "value": "_a_b_c_d_e_f_"
+        },
+        "string_with_only_one_underscore": {
+          "key": "string_with_only_one_underscore",
+          "value": "_"
+        },
+        "string_with_only_multiple_underscores": {
+          "key": "string_with_only_multiple_underscores",
+          "value": "_______"
+        },
+        "string_with_plus_signs": {
+          "key": "string_with_plus_signs",
+          "value": "+a+b+c+d+e+f+"
+        },
+        "string_with_only_one_plus_sign": {
+          "key": "string_with_only_one_plus_sign",
+          "value": "+"
+        },
+        "string_with_only_multiple_plus_signs": {
+          "key": "string_with_only_multiple_plus_signs",
+          "value": "+++++++"
+        },
+        "string_with_equal_signs": {
+          "key": "string_with_equal_signs",
+          "value": "=a=b=c=d=e=f="
+        },
+        "string_with_only_one_equal_sign": {
+          "key": "string_with_only_one_equal_sign",
+          "value": "="
+        },
+        "string_with_only_multiple_equal_signs": {
+          "key": "string_with_only_multiple_equal_signs",
+          "value": "======="
+        },
+        "string_with_dollar_signs": {
+          "key": "string_with_dollar_signs",
+          "value": "$a$b$c$d$e$f$"
+        },
+        "string_with_only_one_dollar_sign": {
+          "key": "string_with_only_one_dollar_sign",
+          "value": "$"
+        },
+        "string_with_only_multiple_dollar_signs": {
+          "key": "string_with_only_multiple_dollar_signs",
+          "value": "$$$$$$$"
+        },
+        "string_with_at_signs": {
+          "key": "string_with_at_signs",
+          "value": "@a@b@c@d@e@f@"
+        },
+        "string_with_only_one_at_sign": {
+          "key": "string_with_only_one_at_sign",
+          "value": "@"
+        },
+        "string_with_only_multiple_at_signs": {
+          "key": "string_with_only_multiple_at_signs",
+          "value": "@@@@@@@"
+        },
+        "string_with_amp_signs": {
+          "key": "string_with_amp_signs",
+          "value": "&a&b&c&d&e&f&"
+        },
+        "string_with_only_one_amp_sign": {
+          "key": "string_with_only_one_amp_sign",
+          "value": "&"
+        },
+        "string_with_only_multiple_amp_signs": {
+          "key": "string_with_only_multiple_amp_signs",
+          "value": "&&&&&&&"
+        },
+        "string_with_hash_signs": {
+          "key": "string_with_hash_signs",
+          "value": "#a#b#c#d#e#f#"
+        },
+        "string_with_only_one_hash_sign": {
+          "key": "string_with_only_one_hash_sign",
+          "value": "#"
+        },
+        "string_with_only_multiple_hash_signs": {
+          "key": "string_with_only_multiple_hash_signs",
+          "value": "#######"
+        },
+        "string_with_percentage_signs": {
+          "key": "string_with_percentage_signs",
+          "value": "%a%b%c%d%e%f%"
+        },
+        "string_with_only_one_percentage_sign": {
+          "key": "string_with_only_one_percentage_sign",
+          "value": "%"
+        },
+        "string_with_only_multiple_percentage_signs": {
+          "key": "string_with_only_multiple_percentage_signs",
+          "value": "%%%%%%%"
+        },
+        "string_with_tilde_signs": {
+          "key": "string_with_tilde_signs",
+          "value": "~a~b~c~d~e~f~"
+        },
+        "string_with_only_one_tilde_sign": {
+          "key": "string_with_only_one_tilde_sign",
+          "value": "~"
+        },
+        "string_with_only_multiple_tilde_signs": {
+          "key": "string_with_only_multiple_tilde_signs",
+          "value": "~~~~~~~"
+        },
+        "string_with_asterix_signs": {
+          "key": "string_with_asterix_signs",
+          "value": "*a*b*c*d*e*f*"
+        },
+        "string_with_only_one_asterix_sign": {
+          "key": "string_with_only_one_asterix_sign",
+          "value": "*"
+        },
+        "string_with_only_multiple_asterix_signs": {
+          "key": "string_with_only_multiple_asterix_signs",
+          "value": "*******"
+        },
+        "string_with_single_quotes": {
+          "key": "string_with_single_quotes",
+          "value": "'a'b'c'd'e'f'"
+        },
+        "string_with_only_one_single_quote": {
+          "key": "string_with_only_one_single_quote",
+          "value": "'"
+        },
+        "string_with_only_multiple_single_quotes": {
+          "key": "string_with_only_multiple_single_quotes",
+          "value": "'''''''"
+        },
+        "string_with_question_marks": {
+          "key": "string_with_question_marks",
+          "value": "?a?b?c?d?e?f?"
+        },
+        "string_with_only_one_question_mark": {
+          "key": "string_with_only_one_question_mark",
+          "value": "?"
+        },
+        "string_with_only_multiple_question_marks": {
+          "key": "string_with_only_multiple_question_marks",
+          "value": "???????"
+        },
+        "string_with_exclamation_marks": {
+          "key": "string_with_exclamation_marks",
+          "value": "!a!b!c!d!e!f!"
+        },
+        "string_with_only_one_exclamation_mark": {
+          "key": "string_with_only_one_exclamation_mark",
+          "value": "!"
+        },
+        "string_with_only_multiple_exclamation_marks": {
+          "key": "string_with_only_multiple_exclamation_marks",
+          "value": "!!!!!!!"
+        },
+        "string_with_opening_parentheses": {
+          "key": "string_with_opening_parentheses",
+          "value": "(a(b(c(d(e(f("
+        },
+        "string_with_only_one_opening_parenthese": {
+          "key": "string_with_only_one_opening_parenthese",
+          "value": "("
+        },
+        "string_with_only_multiple_opening_parentheses": {
+          "key": "string_with_only_multiple_opening_parentheses",
+          "value": "((((((("
+        },
+        "string_with_closing_parentheses": {
+          "key": "string_with_closing_parentheses",
+          "value": ")a)b)c)d)e)f)"
+        },
+        "string_with_only_one_closing_parenthese": {
+          "key": "string_with_only_one_closing_parenthese",
+          "value": ")"
+        },
+        "string_with_only_multiple_closing_parentheses": {
+          "key": "string_with_only_multiple_closing_parentheses",
+          "value": ")))))))"
+        }
+      },
+      "totalShards": 10000,
+      "allocations": [
+        {
+          "key": "allocation-test-string_with_spaces",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_spaces",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_spaces",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_space",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_space",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_space",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_spaces",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_spaces",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_spaces",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_dots",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_dots",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_dots",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_dot",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_dot",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_dot",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_dots",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_dots",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_dots",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_comas",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_comas",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_comas",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_coma",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_coma",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_coma",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_comas",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_comas",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_comas",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_colons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_colons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_colons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_colon",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_colon",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_colon",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_colons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_colons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_colons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_semicolons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_semicolons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_semicolons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_semicolon",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_semicolon",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_semicolon",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_semicolons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_semicolons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_semicolons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_slashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_slashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_slashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_slash",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_slash",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_slash",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_slashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_slashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_slashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_dashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_dashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_dashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_dash",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_dash",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_dash",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_dashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_dashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_dashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_underscores",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_underscores",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_underscores",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_underscore",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_underscore",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_underscore",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_underscores",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_underscores",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_underscores",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_plus_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_plus_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_plus_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_plus_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_plus_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_plus_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_plus_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_plus_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_plus_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_equal_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_equal_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_equal_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_equal_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_equal_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_equal_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_equal_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_equal_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_equal_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_dollar_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_dollar_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_dollar_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_dollar_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_dollar_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_dollar_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_dollar_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_dollar_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_dollar_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_at_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_at_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_at_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_at_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_at_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_at_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_at_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_at_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_at_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_amp_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_amp_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_amp_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_amp_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_amp_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_amp_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_amp_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_amp_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_amp_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_hash_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_hash_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_hash_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_hash_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_hash_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_hash_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_hash_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_hash_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_hash_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_percentage_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_percentage_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_percentage_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_percentage_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_percentage_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_percentage_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_percentage_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_percentage_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_percentage_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_tilde_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_tilde_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_tilde_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_tilde_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_tilde_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_tilde_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_tilde_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_tilde_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_tilde_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_asterix_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_asterix_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_asterix_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_asterix_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_asterix_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_asterix_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_asterix_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_asterix_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_asterix_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_single_quotes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_single_quotes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_single_quotes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_single_quote",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_single_quote",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_single_quote",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_single_quotes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_single_quotes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_single_quotes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_question_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_question_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_question_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_question_mark",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_question_mark",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_question_mark",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_question_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_question_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_question_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_exclamation_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_exclamation_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_exclamation_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_exclamation_mark",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_exclamation_mark",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_exclamation_mark",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_exclamation_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_exclamation_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_opening_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_opening_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_opening_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_opening_parenthese",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_opening_parenthese",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_opening_parenthese",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_opening_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_opening_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_closing_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_closing_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_closing_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_closing_parenthese",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_closing_parenthese",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_closing_parenthese",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_closing_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_closing_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
     }
   }
 }

--- a/ufc/tests/test-string-with-special-characters.json
+++ b/ufc/tests/test-string-with-special-characters.json
@@ -1,0 +1,23831 @@
+{
+  "flag": "string_flag_with_special_characters",
+  "variationType": "STRING",
+  "defaultValue": "default_value",
+  "subjects": [
+    {
+      "subjectKey": "string_with_spaces",
+      "subjectAttributes": {
+        "string_with_spaces": true
+      },
+      "assignment": " a b c d e f ",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_spaces\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_spaces",
+        "variationValue": " a b c d e f ",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_spaces",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_spaces",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 1
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_space",
+      "subjectAttributes": {
+        "string_with_only_one_space": true
+      },
+      "assignment": " ",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_space\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_space",
+        "variationValue": " ",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_space",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_space",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_spaces",
+      "subjectAttributes": {
+        "string_with_only_multiple_spaces": true
+      },
+      "assignment": "       ",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_spaces\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_spaces",
+        "variationValue": "       ",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_spaces",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_spaces",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 3
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_dots",
+      "subjectAttributes": {
+        "string_with_dots": true
+      },
+      "assignment": ".a.b.c.d.e.f.",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_dots\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_dots",
+        "variationValue": ".a.b.c.d.e.f.",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_dots",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_dots",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 4
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_dot",
+      "subjectAttributes": {
+        "string_with_only_one_dot": true
+      },
+      "assignment": ".",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_dot\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_dot",
+        "variationValue": ".",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_dot",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_dot",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 5
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_dots",
+      "subjectAttributes": {
+        "string_with_only_multiple_dots": true
+      },
+      "assignment": ".......",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_dots\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_dots",
+        "variationValue": ".......",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_dots",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_dots",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 6
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_comas",
+      "subjectAttributes": {
+        "string_with_comas": true
+      },
+      "assignment": ",a,b,c,d,e,f,",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_comas\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_comas",
+        "variationValue": ",a,b,c,d,e,f,",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_comas",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_comas",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 7
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_coma",
+      "subjectAttributes": {
+        "string_with_only_one_coma": true
+      },
+      "assignment": ",",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_coma\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_coma",
+        "variationValue": ",",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_coma",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_coma",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 8
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_comas",
+      "subjectAttributes": {
+        "string_with_only_multiple_comas": true
+      },
+      "assignment": ",,,,,,,",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_comas\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_comas",
+        "variationValue": ",,,,,,,",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_comas",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_comas",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 9
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_colons",
+      "subjectAttributes": {
+        "string_with_colons": true
+      },
+      "assignment": ":a:b:c:d:e:f:",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_colons\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_colons",
+        "variationValue": ":a:b:c:d:e:f:",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_colons",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_colons",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 10
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_colon",
+      "subjectAttributes": {
+        "string_with_only_one_colon": true
+      },
+      "assignment": ":",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_colon\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_colon",
+        "variationValue": ":",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_colon",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_colon",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 11
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_colons",
+      "subjectAttributes": {
+        "string_with_only_multiple_colons": true
+      },
+      "assignment": ":::::::",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_colons\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_colons",
+        "variationValue": ":::::::",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_colons",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_colons",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 12
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_semicolons",
+      "subjectAttributes": {
+        "string_with_semicolons": true
+      },
+      "assignment": ";a;b;c;d;e;f;",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_semicolons\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_semicolons",
+        "variationValue": ";a;b;c;d;e;f;",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_semicolons",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_semicolons",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 13
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_semicolon",
+      "subjectAttributes": {
+        "string_with_only_one_semicolon": true
+      },
+      "assignment": ";",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_semicolon\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_semicolon",
+        "variationValue": ";",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_semicolon",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_semicolon",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 14
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_semicolons",
+      "subjectAttributes": {
+        "string_with_only_multiple_semicolons": true
+      },
+      "assignment": ";;;;;;;",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_semicolons\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_semicolons",
+        "variationValue": ";;;;;;;",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_semicolons",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_semicolons",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 15
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_slashes",
+      "subjectAttributes": {
+        "string_with_slashes": true
+      },
+      "assignment": "/a/b/c/d/e/f/",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_slashes\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_slashes",
+        "variationValue": "/a/b/c/d/e/f/",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_slashes",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_slashes",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 16
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_slash",
+      "subjectAttributes": {
+        "string_with_only_one_slash": true
+      },
+      "assignment": "/",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_slash\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_slash",
+        "variationValue": "/",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_slash",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_slash",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 17
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_slashes",
+      "subjectAttributes": {
+        "string_with_only_multiple_slashes": true
+      },
+      "assignment": "///////",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_slashes\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_slashes",
+        "variationValue": "///////",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_slashes",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_slashes",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 18
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_dashes",
+      "subjectAttributes": {
+        "string_with_dashes": true
+      },
+      "assignment": "-a-b-c-d-e-f-",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_dashes\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_dashes",
+        "variationValue": "-a-b-c-d-e-f-",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_dashes",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_dashes",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 19
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_dash",
+      "subjectAttributes": {
+        "string_with_only_one_dash": true
+      },
+      "assignment": "-",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_dash\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_dash",
+        "variationValue": "-",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_dash",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_dash",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 20
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_dashes",
+      "subjectAttributes": {
+        "string_with_only_multiple_dashes": true
+      },
+      "assignment": "-------",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_dashes\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_dashes",
+        "variationValue": "-------",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_dashes",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_dashes",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 21
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_underscores",
+      "subjectAttributes": {
+        "string_with_underscores": true
+      },
+      "assignment": "_a_b_c_d_e_f_",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_underscores\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_underscores",
+        "variationValue": "_a_b_c_d_e_f_",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_underscores",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_underscores",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 22
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_underscore",
+      "subjectAttributes": {
+        "string_with_only_one_underscore": true
+      },
+      "assignment": "_",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_underscore\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_underscore",
+        "variationValue": "_",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_underscore",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_underscore",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 23
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_underscores",
+      "subjectAttributes": {
+        "string_with_only_multiple_underscores": true
+      },
+      "assignment": "_______",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_underscores\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_underscores",
+        "variationValue": "_______",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_underscores",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_underscores",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 24
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_plus_signs",
+      "subjectAttributes": {
+        "string_with_plus_signs": true
+      },
+      "assignment": "+a+b+c+d+e+f+",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_plus_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_plus_signs",
+        "variationValue": "+a+b+c+d+e+f+",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_plus_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_plus_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 25
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_plus_sign",
+      "subjectAttributes": {
+        "string_with_only_one_plus_sign": true
+      },
+      "assignment": "+",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_plus_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_plus_sign",
+        "variationValue": "+",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_plus_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_plus_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 26
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_plus_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_plus_signs": true
+      },
+      "assignment": "+++++++",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_plus_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_plus_signs",
+        "variationValue": "+++++++",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_plus_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_plus_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 27
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_equal_signs",
+      "subjectAttributes": {
+        "string_with_equal_signs": true
+      },
+      "assignment": "=a=b=c=d=e=f=",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_equal_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_equal_signs",
+        "variationValue": "=a=b=c=d=e=f=",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_equal_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_equal_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 28
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_equal_sign",
+      "subjectAttributes": {
+        "string_with_only_one_equal_sign": true
+      },
+      "assignment": "=",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_equal_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_equal_sign",
+        "variationValue": "=",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_equal_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_equal_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 29
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_equal_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_equal_signs": true
+      },
+      "assignment": "=======",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_equal_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_equal_signs",
+        "variationValue": "=======",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_equal_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_equal_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 30
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_dollar_signs",
+      "subjectAttributes": {
+        "string_with_dollar_signs": true
+      },
+      "assignment": "$a$b$c$d$e$f$",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_dollar_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_dollar_signs",
+        "variationValue": "$a$b$c$d$e$f$",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_dollar_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_dollar_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 31
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_dollar_sign",
+      "subjectAttributes": {
+        "string_with_only_one_dollar_sign": true
+      },
+      "assignment": "$",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_dollar_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_dollar_sign",
+        "variationValue": "$",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_dollar_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_dollar_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 32
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_dollar_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_dollar_signs": true
+      },
+      "assignment": "$$$$$$$",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_dollar_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_dollar_signs",
+        "variationValue": "$$$$$$$",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_dollar_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_dollar_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 33
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_at_signs",
+      "subjectAttributes": {
+        "string_with_at_signs": true
+      },
+      "assignment": "@a@b@c@d@e@f@",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_at_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_at_signs",
+        "variationValue": "@a@b@c@d@e@f@",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_at_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_at_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 34
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_at_sign",
+      "subjectAttributes": {
+        "string_with_only_one_at_sign": true
+      },
+      "assignment": "@",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_at_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_at_sign",
+        "variationValue": "@",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_at_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_at_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 35
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_at_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_at_signs": true
+      },
+      "assignment": "@@@@@@@",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_at_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_at_signs",
+        "variationValue": "@@@@@@@",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_at_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_at_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 36
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_amp_signs",
+      "subjectAttributes": {
+        "string_with_amp_signs": true
+      },
+      "assignment": "&a&b&c&d&e&f&",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_amp_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_amp_signs",
+        "variationValue": "&a&b&c&d&e&f&",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_amp_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_amp_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 37
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_amp_sign",
+      "subjectAttributes": {
+        "string_with_only_one_amp_sign": true
+      },
+      "assignment": "&",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_amp_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_amp_sign",
+        "variationValue": "&",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_amp_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_amp_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 38
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_amp_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_amp_signs": true
+      },
+      "assignment": "&&&&&&&",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_amp_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_amp_signs",
+        "variationValue": "&&&&&&&",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_amp_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_amp_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 39
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_hash_signs",
+      "subjectAttributes": {
+        "string_with_hash_signs": true
+      },
+      "assignment": "#a#b#c#d#e#f#",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_hash_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_hash_signs",
+        "variationValue": "#a#b#c#d#e#f#",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_hash_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_hash_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 40
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_hash_sign",
+      "subjectAttributes": {
+        "string_with_only_one_hash_sign": true
+      },
+      "assignment": "#",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_hash_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_hash_sign",
+        "variationValue": "#",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_hash_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_hash_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 41
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_hash_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_hash_signs": true
+      },
+      "assignment": "#######",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_hash_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_hash_signs",
+        "variationValue": "#######",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_hash_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_hash_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 42
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_percentage_signs",
+      "subjectAttributes": {
+        "string_with_percentage_signs": true
+      },
+      "assignment": "%a%b%c%d%e%f%",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_percentage_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_percentage_signs",
+        "variationValue": "%a%b%c%d%e%f%",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_percentage_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_percentage_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 43
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_percentage_sign",
+      "subjectAttributes": {
+        "string_with_only_one_percentage_sign": true
+      },
+      "assignment": "%",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_percentage_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_percentage_sign",
+        "variationValue": "%",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_percentage_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_percentage_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 44
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_percentage_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_percentage_signs": true
+      },
+      "assignment": "%%%%%%%",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_percentage_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_percentage_signs",
+        "variationValue": "%%%%%%%",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_percentage_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_percentage_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 45
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_tilde_signs",
+      "subjectAttributes": {
+        "string_with_tilde_signs": true
+      },
+      "assignment": "~a~b~c~d~e~f~",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_tilde_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_tilde_signs",
+        "variationValue": "~a~b~c~d~e~f~",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_tilde_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_tilde_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 46
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_tilde_sign",
+      "subjectAttributes": {
+        "string_with_only_one_tilde_sign": true
+      },
+      "assignment": "~",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_tilde_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_tilde_sign",
+        "variationValue": "~",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_tilde_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_tilde_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 47
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_tilde_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_tilde_signs": true
+      },
+      "assignment": "~~~~~~~",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_tilde_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_tilde_signs",
+        "variationValue": "~~~~~~~",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_tilde_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_tilde_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 48
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_asterix_signs",
+      "subjectAttributes": {
+        "string_with_asterix_signs": true
+      },
+      "assignment": "*a*b*c*d*e*f*",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_asterix_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_asterix_signs",
+        "variationValue": "*a*b*c*d*e*f*",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_asterix_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_asterix_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 49
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_asterix_sign",
+      "subjectAttributes": {
+        "string_with_only_one_asterix_sign": true
+      },
+      "assignment": "*",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_asterix_sign\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_asterix_sign",
+        "variationValue": "*",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_asterix_sign",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_asterix_sign",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 50
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_asterix_signs",
+      "subjectAttributes": {
+        "string_with_only_multiple_asterix_signs": true
+      },
+      "assignment": "*******",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_asterix_signs\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_asterix_signs",
+        "variationValue": "*******",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_asterix_signs",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_asterix_signs",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 51
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_single_quotes",
+      "subjectAttributes": {
+        "string_with_single_quotes": true
+      },
+      "assignment": "'a'b'c'd'e'f'",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_single_quotes\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_single_quotes",
+        "variationValue": "'a'b'c'd'e'f'",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_single_quotes",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_single_quotes",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 52
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_single_quote",
+      "subjectAttributes": {
+        "string_with_only_one_single_quote": true
+      },
+      "assignment": "'",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_single_quote\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_single_quote",
+        "variationValue": "'",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_single_quote",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_single_quote",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 53
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_single_quotes",
+      "subjectAttributes": {
+        "string_with_only_multiple_single_quotes": true
+      },
+      "assignment": "'''''''",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_single_quotes\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_single_quotes",
+        "variationValue": "'''''''",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_single_quotes",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_single_quotes",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 54
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_question_marks",
+      "subjectAttributes": {
+        "string_with_question_marks": true
+      },
+      "assignment": "?a?b?c?d?e?f?",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_question_marks\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_question_marks",
+        "variationValue": "?a?b?c?d?e?f?",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_question_marks",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_question_marks",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 55
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_question_mark",
+      "subjectAttributes": {
+        "string_with_only_one_question_mark": true
+      },
+      "assignment": "?",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_question_mark\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_question_mark",
+        "variationValue": "?",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_question_mark",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_question_mark",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 56
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_question_marks",
+      "subjectAttributes": {
+        "string_with_only_multiple_question_marks": true
+      },
+      "assignment": "???????",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_question_marks\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_question_marks",
+        "variationValue": "???????",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_question_marks",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_question_marks",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 57
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_exclamation_marks",
+      "subjectAttributes": {
+        "string_with_exclamation_marks": true
+      },
+      "assignment": "!a!b!c!d!e!f!",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_exclamation_marks\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_exclamation_marks",
+        "variationValue": "!a!b!c!d!e!f!",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_exclamation_marks",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_exclamation_marks",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 58
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_exclamation_mark",
+      "subjectAttributes": {
+        "string_with_only_one_exclamation_mark": true
+      },
+      "assignment": "!",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_exclamation_mark\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_exclamation_mark",
+        "variationValue": "!",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_exclamation_mark",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_exclamation_mark",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 59
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_exclamation_marks",
+      "subjectAttributes": {
+        "string_with_only_multiple_exclamation_marks": true
+      },
+      "assignment": "!!!!!!!",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_exclamation_marks\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_exclamation_marks",
+        "variationValue": "!!!!!!!",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_exclamation_marks",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 60
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 59
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_opening_parentheses",
+      "subjectAttributes": {
+        "string_with_opening_parentheses": true
+      },
+      "assignment": "(a(b(c(d(e(f(",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_opening_parentheses\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_opening_parentheses",
+        "variationValue": "(a(b(c(d(e(f(",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_opening_parentheses",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_opening_parentheses",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 61
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 60
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_opening_parenthese",
+      "subjectAttributes": {
+        "string_with_only_one_opening_parenthese": true
+      },
+      "assignment": "(",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_opening_parenthese\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_opening_parenthese",
+        "variationValue": "(",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_opening_parenthese",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_opening_parenthese",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 62
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 61
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_opening_parentheses",
+      "subjectAttributes": {
+        "string_with_only_multiple_opening_parentheses": true
+      },
+      "assignment": "(((((((",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_opening_parentheses\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_opening_parentheses",
+        "variationValue": "(((((((",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_opening_parentheses",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 63
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 62
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_closing_parentheses",
+      "subjectAttributes": {
+        "string_with_closing_parentheses": true
+      },
+      "assignment": ")a)b)c)d)e)f)",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_closing_parentheses\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_closing_parentheses",
+        "variationValue": ")a)b)c)d)e)f)",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_closing_parentheses",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_closing_parentheses",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 64
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 63
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 65
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_one_closing_parenthese",
+      "subjectAttributes": {
+        "string_with_only_one_closing_parenthese": true
+      },
+      "assignment": ")",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_one_closing_parenthese\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_one_closing_parenthese",
+        "variationValue": ")",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_one_closing_parenthese",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_one_closing_parenthese",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 65
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 64
+          }
+        ],
+        "unevaluatedAllocations": [
+          {
+            "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 66
+          }
+        ]
+      }
+    },
+    {
+      "subjectKey": "string_with_only_multiple_closing_parentheses",
+      "subjectAttributes": {
+        "string_with_only_multiple_closing_parentheses": true
+      },
+      "assignment": ")))))))",
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"allocation-test-string_with_only_multiple_closing_parentheses\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "string_with_only_multiple_closing_parentheses",
+        "variationValue": ")))))))",
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "string_with_only_multiple_closing_parentheses",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 66
+        },
+        "unmatchedAllocations": [
+          {
+            "key": "allocation-test-string_with_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          },
+          {
+            "key": "allocation-test-string_with_only_one_space",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 2
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_spaces",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 3
+          },
+          {
+            "key": "allocation-test-string_with_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 4
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dot",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 5
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dots",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 6
+          },
+          {
+            "key": "allocation-test-string_with_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 7
+          },
+          {
+            "key": "allocation-test-string_with_only_one_coma",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 8
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_comas",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 9
+          },
+          {
+            "key": "allocation-test-string_with_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 10
+          },
+          {
+            "key": "allocation-test-string_with_only_one_colon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 11
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_colons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 12
+          },
+          {
+            "key": "allocation-test-string_with_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 13
+          },
+          {
+            "key": "allocation-test-string_with_only_one_semicolon",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 14
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_semicolons",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 15
+          },
+          {
+            "key": "allocation-test-string_with_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 16
+          },
+          {
+            "key": "allocation-test-string_with_only_one_slash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 17
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_slashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 18
+          },
+          {
+            "key": "allocation-test-string_with_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 19
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dash",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 20
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dashes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 21
+          },
+          {
+            "key": "allocation-test-string_with_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 22
+          },
+          {
+            "key": "allocation-test-string_with_only_one_underscore",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 23
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_underscores",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 24
+          },
+          {
+            "key": "allocation-test-string_with_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 25
+          },
+          {
+            "key": "allocation-test-string_with_only_one_plus_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 26
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_plus_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 27
+          },
+          {
+            "key": "allocation-test-string_with_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 28
+          },
+          {
+            "key": "allocation-test-string_with_only_one_equal_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 29
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_equal_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 30
+          },
+          {
+            "key": "allocation-test-string_with_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 31
+          },
+          {
+            "key": "allocation-test-string_with_only_one_dollar_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 32
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_dollar_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 33
+          },
+          {
+            "key": "allocation-test-string_with_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 34
+          },
+          {
+            "key": "allocation-test-string_with_only_one_at_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 35
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_at_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 36
+          },
+          {
+            "key": "allocation-test-string_with_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 37
+          },
+          {
+            "key": "allocation-test-string_with_only_one_amp_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 38
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_amp_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 39
+          },
+          {
+            "key": "allocation-test-string_with_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 40
+          },
+          {
+            "key": "allocation-test-string_with_only_one_hash_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 41
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_hash_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 42
+          },
+          {
+            "key": "allocation-test-string_with_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 43
+          },
+          {
+            "key": "allocation-test-string_with_only_one_percentage_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 44
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_percentage_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 45
+          },
+          {
+            "key": "allocation-test-string_with_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 46
+          },
+          {
+            "key": "allocation-test-string_with_only_one_tilde_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 47
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_tilde_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 48
+          },
+          {
+            "key": "allocation-test-string_with_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 49
+          },
+          {
+            "key": "allocation-test-string_with_only_one_asterix_sign",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 50
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_asterix_signs",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 51
+          },
+          {
+            "key": "allocation-test-string_with_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 52
+          },
+          {
+            "key": "allocation-test-string_with_only_one_single_quote",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 53
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_single_quotes",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 54
+          },
+          {
+            "key": "allocation-test-string_with_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 55
+          },
+          {
+            "key": "allocation-test-string_with_only_one_question_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 56
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_question_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 57
+          },
+          {
+            "key": "allocation-test-string_with_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 58
+          },
+          {
+            "key": "allocation-test-string_with_only_one_exclamation_mark",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 59
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 60
+          },
+          {
+            "key": "allocation-test-string_with_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 61
+          },
+          {
+            "key": "allocation-test-string_with_only_one_opening_parenthese",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 62
+          },
+          {
+            "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 63
+          },
+          {
+            "key": "allocation-test-string_with_closing_parentheses",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 64
+          },
+          {
+            "key": "allocation-test-string_with_only_one_closing_parenthese",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 65
+          }
+        ],
+        "unevaluatedAllocations": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Eppo Internal:
🎟️ Ticket: [FF-4069 - Adjust Shared SDK Test Data to Ensure SDKs can handle non-alphanumeric characters in String values](https://linear.app/eppo/issue/FF-4069/adjust-shared-sdk-test-data-to-ensure-sdks-can-handle-non-alphanumeric)

Description:
SDKs need to be able to handle special characters in values for the variations of type STRING. This PR adds a test cases to check all possible allowed special characters as values of the variations. Test cases cover single inclusion of special character, multiple special characters divided by regular ones, multiple repeating special characters as a whole variation value.