### PR TITLE
chore: use actions/cache@v4

### DIFF
--- a/.github/workflows/validate-test-data.yml
+++ b/.github/workflows/validate-test-data.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: './node_modules'
           key: ${{ runner.os }}-root-node-modules-${{ hashFiles('./yarn.lock') }}


### PR DESCRIPTION
upgrade to v4 because actions/cache@v2 is deprecated
https://github.com/Eppo-exp/sdk-test-data/actions/runs/13677237873/job/38240394019