### PR TITLE
fix: correctly specify the SDK name under test for node-server

### DIFF
--- a/.github/workflows/test-sdk-packages.yml
+++ b/.github/workflows/test-sdk-packages.yml
@@ -40,6 +40,6 @@ jobs:
     uses: ./.github/workflows/test-server-sdk.yml
     with:
       platform: ${{ matrix.platform }}
-      sdkName: 'eppo/node-server-sdk'
+      sdkName: 'node-server-sdk'
       sdkRelayDir: 'node-sdk-relay'
     secrets: inherit

--- a/package-testing/node-sdk-relay/package.json
+++ b/package-testing/node-sdk-relay/package.json
@@ -21,7 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@eppo/node-server-sdk": "^3.7.2",
+    "@eppo/node-server-sdk": "^3.9.3",
     "@eslint/js": "^9.16.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",

--- a/package-testing/node-sdk-relay/src/app.controller.ts
+++ b/package-testing/node-sdk-relay/src/app.controller.ts
@@ -4,6 +4,7 @@ import { AssignmentDto, BanditDto, BanditTestRunnerInput } from './types';
 import { EppoClientProxy } from './eppoClientProxy';
 import { BanditActions, getInstance, init } from '@eppo/node-server-sdk';
 import getLogger from './main';
+import { sdkName, sdkVersion } from '@eppo/node-server-sdk/dist/sdk-data';
 
 @Controller()
 export class AppController {
@@ -13,6 +14,11 @@ export class AppController {
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Get('sdk/details')
+  getSdkDetails() {
+    return { sdkName, sdkVersion, supportsBandits: true, supportsDynamicTyping: true };
   }
 
   @Post('flags/v1/assignment')

--- a/package-testing/node-sdk-relay/yarn.lock
+++ b/package-testing/node-sdk-relay/yarn.lock
@@ -320,10 +320,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eppo/js-client-sdk-common@4.8.4":
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.8.4.tgz#a1919233fa52399b86ce75b9eebed1c6d2bac16e"
-  integrity sha512-cDxOOHjGU0kJLp2zXWGXaH2xcEd/oxsAT4e78jbbhktb+e5vkU3+SCFTvijFykr1h/hQ2a3O1PPP0M8HFfdrZA==
+"@eppo/js-client-sdk-common@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.14.1.tgz#db908420c47a1327921493072892923e58c2039f"
+  integrity sha512-trXgxPgbS+vFkYd0w0Xb2V9NntE2SgLsThhxoDbRENw1ynb8b8b3MDdwFH+5DheVT1ji6mZ+Qrh40uNIxMptYA==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"
@@ -332,12 +332,12 @@
     spark-md5 "^3.0.2"
     uuid "^11.0.5"
 
-"@eppo/node-server-sdk@^3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@eppo/node-server-sdk/-/node-server-sdk-3.7.2.tgz#086f5a211ab848792afb4a9292396e60bf5bfd62"
-  integrity sha512-rFXZx4312AbWTwB2astTCNZv1K9sMfRXvWRYJQuidfojqG8iDH0+l1nBCH9GPSNgNw4hdoh1pj4leX8tTkwRoQ==
+"@eppo/node-server-sdk@^3.9.3":
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/@eppo/node-server-sdk/-/node-server-sdk-3.9.3.tgz#5954ed53ca676880642ed821f37ef07fe06862bd"
+  integrity sha512-yHPTJkYhHszKWWXKrgtbBr4Ugsf4fCP+6pDi3o6zU8HJu2lK5QN+bROaKAeILwBY8dD+h8+CHZnFZpq1JmdK3g==
   dependencies:
-    "@eppo/js-client-sdk-common" "4.8.4"
+    "@eppo/js-client-sdk-common" "4.14.1"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.1"

--- a/package-testing/sdk-test-runner/package.json
+++ b/package-testing/sdk-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk-test-runner",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Test runner for SDK package testing",
   "main": "src/app.ts",
   "repository": "https://github.com/Eppo-exp/sdk-test-data",


### PR DESCRIPTION
## Motivation and Context
The `node-server-sdk` package test has been failing because the wrong SDK name is specified to the test runner

## Changes
- Specify the correct name in the GH action
- Check the connected SDK against the expected SDK in the sdk-test-runner
- Return SDK Details from the node sdk relay server (which, combined with the above check would have surfaced this issue immediately)