### PR TITLE
fix: specify proper python SDK name

### DIFF
--- a/.github/workflows/test-sdk-packages.yml
+++ b/.github/workflows/test-sdk-packages.yml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/test-server-sdk.yml
     with:
       platform: ${{ matrix.platform }}
-      sdkName: 'eppo/python-sdk'
+      sdkName: 'python-sdk'
       sdkRelayDir: 'python-sdk-relay'
     secrets: inherit
 


### PR DESCRIPTION
A recent change has surfaced this mismatch

![image](https://github.com/user-attachments/assets/3f36fa79-32c2-429a-9f1d-81cd981e796d)
