### PR TITLE
Test case for empty JSON object variation value

### DIFF
--- a/ufc/flags-v1-obfuscated.json
+++ b/ufc/flags-v1-obfuscated.json
@@ -1199,9 +1199,46 @@
         "dHdv": {
           "key": "dHdv",
           "value": "eyAiaW50ZWdlciI6IDIsICJzdHJpbmciOiAidHdvIiwgImZsb2F0IjogMi4wIH0="
+        },
+        "ZW1wdHk=": {
+          "key": "ZW1wdHk=",
+          "value": "e30="
         }
       },
       "allocations": [
+        {
+          "doLog": true,
+          "key": "T3B0aW9uYWxseSBGb3JjZSBFbXB0eQ==",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "4e1d9d66e21dde70a7dfd7b26a9aa007",
+                  "operator": "27457ce369f2a74203396a35ef537c0b",
+                  "value": [
+                    "b326b5062b2f0e69046810717534cb09"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "shards": [
+                {
+                  "ranges": [
+                    {
+                      "end": 10000,
+                      "start": 0
+                    }
+                  ],
+                  "salt": "ZnVsbC1yYW5nZS1zYWx0"
+                }
+              ],
+              "variationKey": "ZW1wdHk="
+            }
+          ]
+        },
         {
           "key": "NTAvNTAgc3BsaXQ=",
           "doLog": true,

--- a/ufc/flags-v1.json
+++ b/ufc/flags-v1.json
@@ -1199,9 +1199,46 @@
         "two": {
           "key": "two",
           "value": "{ \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }"
+        },
+        "empty": {
+          "key": "empty",
+          "value": "{}"
         }
       },
       "allocations": [
+        {
+          "key": "Optionally Force Empty",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "Force Empty",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "empty",
+              "shards": [
+                {
+                  "salt": "full-range-salt",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
         {
           "key": "50/50 split",
           "rules": [],

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -32,7 +32,13 @@
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
-        "unmatchedAllocations": [],
+        "unmatchedAllocations": [
+          {
+            "key": "Optionally Force Empty",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
         "unevaluatedAllocations": []
       }
     },
@@ -65,7 +71,13 @@
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
-        "unmatchedAllocations": [],
+        "unmatchedAllocations": [
+          {
+            "key": "Optionally Force Empty",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
         "unevaluatedAllocations": []
       }
     },
@@ -97,7 +109,13 @@
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 2
         },
-        "unmatchedAllocations": [],
+        "unmatchedAllocations": [
+          {
+            "key": "Optionally Force Empty",
+            "allocationEvaluationCode": "FAILING_RULE",
+            "orderPosition": 1
+          }
+        ],
         "unevaluatedAllocations": []
       }
     },
@@ -132,7 +150,13 @@
           "orderPosition": 1
         },
         "unmatchedAllocations": [],
-        "unevaluatedAllocations": []
+        "unevaluatedAllocations": [
+          {
+            "key": "50/50 split",
+            "allocationEvaluationCode": "UNEVALUATED",
+            "orderPosition": 2
+          }
+        ]
       }
     }
   ]

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -131,7 +131,7 @@
         "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"Optionally Force Empty\".",
         "banditKey": null,
         "banditAction": null,
-        "variationKey": "two",
+        "variationKey": "empty",
         "variationValue": {},
         "matchedRule": {
           "conditions": [

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -128,7 +128,7 @@
       "evaluationDetails": {
         "environmentName": "Test",
         "flagEvaluationCode": "MATCH",
-        "flagEvaluationDescription": "diana belongs to the range of traffic assigned to \"empty\" defined in allocation \"Optionally Force Empty\".",
+        "flagEvaluationDescription": "Supplied attributes match rules defined in allocation \"Optionally Force Empty\".",
         "banditKey": null,
         "banditAction": null,
         "variationKey": "two",

--- a/ufc/tests/test-json-config-flag.json
+++ b/ufc/tests/test-json-config-flag.json
@@ -30,7 +30,7 @@
         "matchedAllocation": {
           "key": "50/50 split",
           "allocationEvaluationCode": "MATCH",
-          "orderPosition": 1
+          "orderPosition": 2
         },
         "unmatchedAllocations": [],
         "unevaluatedAllocations": []
@@ -63,7 +63,7 @@
         "matchedAllocation": {
           "key": "50/50 split",
           "allocationEvaluationCode": "MATCH",
-          "orderPosition": 1
+          "orderPosition": 2
         },
         "unmatchedAllocations": [],
         "unevaluatedAllocations": []
@@ -94,6 +94,40 @@
         "matchedRule": null,
         "matchedAllocation": {
           "key": "50/50 split",
+          "allocationEvaluationCode": "MATCH",
+          "orderPosition": 2
+        },
+        "unmatchedAllocations": [],
+        "unevaluatedAllocations": []
+      }
+    },
+    {
+      "subjectKey": "diana",
+      "subjectAttributes": {
+        "Force Empty": true
+      },
+      "assignment": {},
+      "evaluationDetails": {
+        "environmentName": "Test",
+        "flagEvaluationCode": "MATCH",
+        "flagEvaluationDescription": "diana belongs to the range of traffic assigned to \"empty\" defined in allocation \"Optionally Force Empty\".",
+        "banditKey": null,
+        "banditAction": null,
+        "variationKey": "two",
+        "variationValue": {},
+        "matchedRule": {
+          "conditions": [
+            {
+              "attribute": "Force Empty",
+              "operator": "ONE_OF",
+              "value": [
+                "true"
+              ]
+            }
+          ]
+        },
+        "matchedAllocation": {
+          "key": "Optionally Force Empty",
           "allocationEvaluationCode": "MATCH",
           "orderPosition": 1
         },


### PR DESCRIPTION
_Eppo Internal:_
:ticket: **Ticket:** [FF-4340 - Update shared test data to include empty JSON object](https://linear.app/eppo/issue/FF-4340/update-shared-test-data-to-include-empty-json-object)
🗨️ Slack Convo: ["...We seem to have a constraint against JSON variations that are the empty object..."](https://eppo-group.slack.com/archives/C04KR1GGE3C)

We want to allow empty JSON objects as variation values. Including as a test case to make sure all SDKs can handle this.