### PR TITLE
fix: return empty objects instead of empty arrays

### DIFF
--- a/package-testing/php-sdk-relay/src/AssignmentHandler.php
+++ b/package-testing/php-sdk-relay/src/AssignmentHandler.php
@@ -5,6 +5,7 @@ namespace Eppo\SDKTest;
 use Eppo\EppoClient;
 use Eppo\Exception\EppoClientException;
 use Exception;
+use stdClass;
 
 class AssignmentHandler
 {
@@ -44,6 +45,9 @@ class AssignmentHandler
                 $subjectAttributes,
                 $default
             );
+            if(is_array($result) and count($result) == 0) {
+                $result = new stdClass();
+            }
             $resultResp = [
                 "subjectKey" => $subjectKey,
                 "result" => $result,


### PR DESCRIPTION
PHP handles the JSON objects as _associative arrays_ aka hashmaps/dicts/etc. When non-empty, these associative arrays are json_encoded as objects, however, when empty, they are encoded as empty arrays.