### PR TITLE
fix: bump Dockerfiles to node:22, auto-trigger image builds on main

### DIFF
--- a/.github/workflows/release-sdk-test-runner.yml
+++ b/.github/workflows/release-sdk-test-runner.yml
@@ -9,8 +9,11 @@ on:
         default: '1.0.0'
 
   push:
+    branches:
+      - main
     paths:
-      .github/workflows/release-sdk-test-runner.yml
+      - package-testing/sdk-test-runner/**
+      - .github/workflows/release-sdk-test-runner.yml
 
 jobs:
   build-and-upload:

--- a/.github/workflows/release-sdk-testing-api.yml
+++ b/.github/workflows/release-sdk-testing-api.yml
@@ -9,8 +9,11 @@ on:
         default: '1.0.0'
 
   push:
+    branches:
+      - main
     paths:
-      .github/workflows/release-sdk-testing-api.yml
+      - package-testing/testing-api/**
+      - .github/workflows/release-sdk-testing-api.yml
 
 jobs:
   build-and-upload:

--- a/package-testing/sdk-test-runner/Dockerfile
+++ b/package-testing/sdk-test-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/package-testing/testing-api/Dockerfile
+++ b/package-testing/testing-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:22
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- `testing-api/Dockerfile`: `node:18` → `node:22`
- `sdk-test-runner/Dockerfile`: `node:18-alpine` → `node:22-alpine`
- Both release workflows now trigger automatically on push to `main` when files under their respective docker context directories change

## Why

Node 18 reached EOL April 2025. The eslint 9 / typescript-eslint 8 upgrades in #151 pull in `eslint-visitor-keys@5.x` which requires `Node >=20.19.0`, causing `docker build` to fail for both images. This was hidden because CI pulls pre-built images from GAR rather than building from the Dockerfile on each branch.

The workflow auto-trigger change ensures image rebuilds happen automatically when source files change, rather than requiring a manual `workflow_dispatch`.

## Test plan
- [x] `docker build package-testing/testing-api` succeeds with `node:22`
- [x] `docker build package-testing/sdk-test-runner` succeeds with `node:22-alpine`
- [ ] Merge after / alongside #151