### PR TITLE
Fix java relay host binding for CI

### DIFF
--- a/package-testing/java-server-sdk-relay/build-and-run.sh
+++ b/package-testing/java-server-sdk-relay/build-and-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Set default values for vars
-: "${SDK_RELAY_HOST:=localhost}"
+: "${SDK_RELAY_HOST:=0.0.0.0}"
 : "${SDK_RELAY_PORT:=4000}"
 : "${EPPO_API_KEY:=test-api-key}"
 : "${EPPO_BASE_URL:=http://localhost:5000/api}"


### PR DESCRIPTION
## Summary
- Java relay's `build-and-run.sh` defaulted `SDK_RELAY_HOST` to `localhost`, which on Linux binds Spark Java to `127.0.0.1` only
- The test runner Docker container connects via `host.docker.internal` (resolves to `172.17.0.1`), causing `ECONNREFUSED`
- Fix: default to `0.0.0.0` so the relay accepts connections from all interfaces

## Evidence
- CI run [#26622410924](https://github.com/Eppo-exp/sdk-test-data/actions/runs/26622410924) shows `test-java-sdk` failing with `connect ECONNREFUSED 172.17.0.1:4000`
- All other SDK relays pass because their frameworks bind more permissively
- The relay itself starts fine (sdk.log shows `Listening on localhost:4000`) — it's just unreachable from Docker

## Test plan
- [ ] CI `test-java-sdk` passes on this branch