### PR TITLE
fix(FFESUPPORT-892): bump php-sdk-relay to eppo/php-sdk ^4.0

### DIFF
--- a/package-testing/php-sdk-relay/composer.json
+++ b/package-testing/php-sdk-relay/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "eppo/php-sdk": "^3.2",
+    "eppo/php-sdk": "^4.0",
     "vlucas/phpdotenv": "^5.6",
     "php-http/curl-client": "^2.3",
     "nyholm/psr7": "^1.8",

--- a/package-testing/php-sdk-relay/composer.lock
+++ b/package-testing/php-sdk-relay/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4607b5ef6cee8f91b75caaca02f5213d",
+    "content-hash": "9fe6c2ad834907f9b9b53582994c9a07",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -151,16 +151,16 @@
         },
         {
             "name": "eppo/php-sdk",
-            "version": "v3.5.1",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Eppo-exp/php-sdk.git",
-                "reference": "042071edd256e05813d7f632db2d1ace4189aa61"
+                "reference": "9e252533b8fda074b57ad9cb0804f04f775996c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Eppo-exp/php-sdk/zipball/042071edd256e05813d7f632db2d1ace4189aa61",
-                "reference": "042071edd256e05813d7f632db2d1ace4189aa61",
+                "url": "https://api.github.com/repos/Eppo-exp/php-sdk/zipball/9e252533b8fda074b57ad9cb0804f04f775996c9",
+                "reference": "9e252533b8fda074b57ad9cb0804f04f775996c9",
                 "shasum": ""
             },
             "require": {
@@ -168,9 +168,10 @@
                 "ext-json": "*",
                 "php": "^8.1",
                 "php-http/discovery": "^1.17",
+                "psr/log": "^2.0|^3.0",
                 "psr/simple-cache": "3.*",
                 "shrikeh/teapot": "^2.3",
-                "symfony/cache": "^6.4",
+                "symfony/cache": "^6.4|^7.0",
                 "webclient/ext-redirect": "^2.0"
             },
             "require-dev": {
@@ -202,9 +203,9 @@
             "homepage": "https://github.com/Eppo-exp/php-sdk",
             "support": {
                 "issues": "https://github.com/Eppo-exp/php-sdk/issues",
-                "source": "https://github.com/Eppo-exp/php-sdk/tree/v3.5.1"
+                "source": "https://github.com/Eppo-exp/php-sdk/tree/v4.2.1"
             },
-            "time": "2025-04-07T22:04:25+00:00"
+            "time": "2026-05-26T22:41:16+00:00"
         },
         {
             "name": "fig/http-message-util",


### PR DESCRIPTION
🤖 **Generated from Claude**

Fixes the `php-sdk-relay` test harness so it works with **php-sdk v4.x**. Jira: https://datadoghq.atlassian.net/browse/FFESUPPORT-892

## Problem
php-sdk's **"Package Integration Testing"** CI (via this repo's `test-server-package` action + `php-sdk-relay`) fails deterministically with **"SDK Relay server failed to start"** (green on `main` until 2026-05-26). The relay's `composer.json` pinned `eppo/php-sdk: ^3.2` (locking **v3.5.1**), but php-sdk is now **v4.x**. The action `composer install`s the pinned 3.x deps, then overlays the tested branch's **v4.x source** onto that 3.x vendor tree → the relay runs 4.x code against 3.x-resolved dependencies → crash → port 4000 never comes up. (Surfaced while remediating php-sdk vulns in php-sdk#62, but unrelated to it — that PR is composer.lock-only.)

## Fix
Bump the relay's `eppo/php-sdk` constraint `^3.2 → ^4.0` and regenerate `composer.lock` (**eppo/php-sdk v3.5.1 → v4.2.1**). No relay `src/` changes needed.

## Verification (local, PHP 8.5)
- `composer require eppo/php-sdk:^4.0` resolves cleanly; `composer audit` reports no advisories.
- All `src/*.php` lint clean (`php -l`); the client / `Config` construct against v4.
- End-to-end boot (relay + testing-api) is exercised by CI once this lands on `main`; re-running php-sdk#62's integration job will then go green.

## Scope
`package-testing/php-sdk-relay/composer.json` + `composer.lock` only.
